### PR TITLE
build: Drop Open edX reference from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-Configuration Pull Request
 ---
 
 Make sure that the following steps are done before merging:
@@ -6,4 +5,3 @@ Make sure that the following steps are done before merging:
   - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
   - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
   - [ ] Performed the appropriate testing.
-  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed


### PR DESCRIPTION
Remove heading as well to just tighten things up.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.