### PR TITLE
fix: edxapp worker APM tags

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -18,7 +18,7 @@ fi
 
 {% if EDXAPP_DATADOG_ENABLE %}
 {% set executable = edxapp_venv_bin + '/ddtrace-run ' + executable %}
-export DD_TAGS="service:edx-edxapp-workers-${SERVICE_VARIANT} queue:${QUEUE_NAME} version:{{ app_version }}"
+export DD_TAGS="service:edx-edxapp-${SERVICE_VARIANT}-workers queue:${QUEUE_NAME} version:{{ app_version }}"
 export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 # Copied from edx_django_service playbook for consistency; Datadog
 # trace debug logging issue doesn't actually affect edxapp for some


### PR DESCRIPTION
 the tags 'edx-edxapp-lms-workers' and 'edx-edxapp-cms-workers' are employed for logging purposes. We're adjusting these tags to align the APM tag with the logging

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
