### PR TITLE
temp: pin boto3 to 1.34.115

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -167,7 +167,7 @@ common_pip_pkgs:
   - setuptools==44.1.0
   - virtualenv==20.2.0
   - zipp==1.2.0
-  - boto3
+  - boto3==1.34.115
   - importlib-resources==3.2.1
 
 common_web_user: www-data


### PR DESCRIPTION
We're getting a failure for missing 1.34.116, and not sure if the lack of pin is what is allowing for it to be requested.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
