### PR TITLE
chore: Enable APM profiling and data streaming for xqwatcher

### DIFF
--- a/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
+++ b/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
@@ -21,6 +21,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 # Copied DD_TRACE_LOG_STREAM_HANDLER config from edx_django_service. This is required
 # to disable Datadog trace debug logging.
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQWATCHER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true,DD_TAGS="service:{{ XQWATCHER_DATADOG_APPNAME }} version:{{ app_version }}",DD_TRACE_LOG_STREAM_HANDLER=false,{% endif -%}
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQWATCHER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true,DD_TAGS="service:{{ XQWATCHER_DATADOG_APPNAME }} version:{{ app_version }}",DD_TRACE_LOG_STREAM_HANDLER=false,DD_PROFILING_ENABLED=true,DD_DATA_STREAMS_ENABLED=true,{% endif -%}
 killasgroup=true
 stopasgroup=true


### PR DESCRIPTION
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
