### PR TITLE
Revert "chore: Enable Data streaming and APM profiling edxapp, forum and django service"

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
@@ -34,8 +34,6 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 # other trace-related configs that are documented seem to help, but
 # from testing DD_TRACE_LOG_STREAM_HANDLER=false seems to help.
 export DD_TRACE_LOG_STREAM_HANDLER=false
-export DD_PROFILING_ENABLED=true
-export DD_DATA_STREAMS_ENABLED=true
 {% endif -%}
 
 export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ edx_django_service_name }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -30,8 +30,6 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 export DD_TRACE_LOG_STREAM_HANDLER=false
 # Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
 export DD_TRACE_PYMONGO_ENABLED=false
-export DD_PROFILING_ENABLED=true
-export DD_DATA_STREAMS_ENABLED=true
 {% endif -%}
 
 export PORT="{{ edxapp_cms_gunicorn_port }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -30,8 +30,6 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 export DD_TRACE_LOG_STREAM_HANDLER=false
 # Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
 export DD_TRACE_PYMONGO_ENABLED=false
-export DD_PROFILING_ENABLED=true
-export DD_DATA_STREAMS_ENABLED=true
 {% endif -%}
 
 export PORT="{{ edxapp_lms_gunicorn_port }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -26,8 +26,6 @@ export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 export DD_TRACE_LOG_STREAM_HANDLER=false
 # Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
 export DD_TRACE_PYMONGO_ENABLED=false
-export DD_PROFILING_ENABLED=true
-export DD_DATA_STREAMS_ENABLED=true
 {% endif -%}
 
 

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -93,8 +93,6 @@ forum_base_env: &forum_base_env
   DD_TAGS: "{{ FORUM_DD_TAGS }}"
   DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT: "true"
   DD_TRACE_LOG_STREAM_HANDLER: "false"
-  DD_PROFILING_ENABLED: "true"
-  DD_DATA_STREAMS_ENABLED: "true"
 
 forum_env:
   <<: *forum_base_env


### PR DESCRIPTION
Reverts edx/configuration#27

Note: We think there may be a conflict with New Relic instrumentation, so we are temporarily reverting.