### PR TITLE
temp: Postpone Datadog APM profiling

### DIFF
--- a/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
+++ b/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
@@ -22,8 +22,12 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
-export DD_PROFILING_ENABLED=true
-export DD_DATA_STREAMS_ENABLED=true
+
+# TODO: There seems to be some potential issues enabling APM profiling in both NewRelic and Datadog.
+# A safe bet would be to enable these after NewRelic profiling is disabled.
+# Tracking Ticket: https://2u-internal.atlassian.net/browse/COSMO-296
+# export DD_PROFILING_ENABLED=true
+# export DD_DATA_STREAMS_ENABLED=true
 {% endif -%}
 
 source {{ insights_app_dir }}/insights_env


### PR DESCRIPTION
Based on [🔒this slack thread](https://twou.slack.com/archives/C06DMDFNBJQ/p1717095907456989), there's a potential risk on having both Datadog and NewRelic profiling enabled.
Insights was not deployed yet with these options enabled. It would be safer to roll back the changes made in this previous PR https://github.com/edx/configuration/pull/26 before deploying to prod and enable the feature.
