### PR TITLE
feat!: edxapp python 3.11 upgrade

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -13,7 +13,7 @@
 # any secrets or host identifying information.
 #
 
-EDXAPP_PYTHON_VERSION: "python3.8"
+EDXAPP_PYTHON_VERSION: "python3.11"
 
 # Bucket used for xblock file storage
 EDXAPP_XBLOCK_FS_STORAGE_BUCKET: !!null

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -344,8 +344,8 @@
     - install:app-requirements
 
 - name: Pin pip to a specific version.
-  # Not pinning to the same version as everything else because sandboxes are still python 2.7
-  command: "{{ edxapp_sandbox_venv_dir }}/bin/pip install pip==21.2.1"
+  # Pinning pip to latest version. Constraint will be removed later on.
+  command: "{{ edxapp_sandbox_venv_dir }}/bin/pip install pip==24.0"
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ edxapp_sandbox_user }}"

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -175,11 +175,11 @@
     - install
     - install:base
 
-- name: install python3.8
+- name: install python3.11
   apt:
     pkg:
-      - python3.8-dev
-      - python3.8-distutils
+      - python3.11-dev
+      - python3.11-distutils
     update_cache: yes
   register: install_pkgs
   until: install_pkgs is success


### PR DESCRIPTION
## Description
- Upgrading edx-platform from `Python 3.8` to `Python 3.11`

## Testing
- Change has been tested using sandbox instances and on stage last week. No issues were found with the usual testing workflows and sample problems
