### PR TITLE
feat: Update DD config on insights

### DIFF
--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -53,6 +53,7 @@ INSIGHTS_SEGMENT_IGNORE_EMAIL_REGEX: !!null
 INSIGHTS_THEME_SCSS: 'sass/themes/open-edx.scss'
 INSIGHTS_RESEARCH_URL: 'https://www.edx.org/research-pedagogy'
 INSIGHTS_OPEN_SOURCE_URL: 'http://set-me-please'
+INSIGHTS_DATADOG_ENABLE: "{{COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP}}"
 
 INSIGHTS_DOMAIN: 'insights'
 

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -46,7 +46,7 @@
     - install:app-requirements
 
 - name: "Install Datadog APM requirements"
-  when: COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP
+  when: INSIGHTS_DATADOG_ENABLE
   pip:
     name:
       - ddtrace

--- a/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
+++ b/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
@@ -14,7 +14,7 @@ export NEW_RELIC_APP_NAME="{{ INSIGHTS_NEWRELIC_APPNAME }}"
 export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% endif -%}
 
-{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
+{% if INSIGHTS_DATADOG_ENABLE %}
 {% set executable = insights_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:edx-{{ insights_service_name }} version:{{ app_version }}"
 export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true


### PR DESCRIPTION
Following the [New Relic to Datadog Service APM migration guide](https://2u-internal.atlassian.net/wiki/spaces/ENG/pages/1008500757/How+to+migrate+from+New+Relic+to+Datadog#Service-APM), this flags should enable Insights for logging APMs on Datadog for production.