### PR TITLE
chore: update datadog service name for Analytics API

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -20,6 +20,7 @@ ANALYTICS_API_GIT_IDENTITY: !!null
 analytics_api_service_name: "analytics_api"
 analytics_api_gunicorn_port: "8100"
 
+analytics_api_datadog_service_name: "edx-analytics-api"
 ANALYTICS_API_DJANGO_SETTINGS_MODULE: "analyticsdataserver.settings.production"
 
 analytics_api_environment:

--- a/playbooks/roles/analytics_api/meta/main.yml
+++ b/playbooks/roles/analytics_api/meta/main.yml
@@ -51,3 +51,4 @@ dependencies:
     edx_django_service_enable_newrelic_distributed_tracing: '{{ ANALYTICS_API_ENABLE_NEWRELIC_DISTRIBUTED_TRACING }}'
     edx_django_service_decrypt_config_enabled: '{{ ANALYTICS_API_DECRYPT_CONFIG_ENABLED }}'
     edx_django_service_copy_config_enabled: '{{ ANALYTICS_API_COPY_CONFIG_ENABLED }}'
+    edx_django_datadog_service: '{{ analytics_api_datadog_service_name }}'


### PR DESCRIPTION
Overriding the Analytics API service configuration in Datadog to ensure correct labeling

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
