### PR TITLE
feat: remove task - Add git apt repository

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -53,19 +53,6 @@
     path: /home/vagrant
   register: vagrant_home_dir
 
-# Ensure that we get a current version of Git
-# GitHub requires version 1.7.10 or later
-# https://help.github.com/articles/https-cloning-errors
-- name: Add git apt repository
-  apt_repository:
-    repo: "{{ common_git_ppa }}"
-    update_cache: yes
-  register: add_repo
-  until: add_repo is success
-  retries: 10
-  delay: 5
-  when: ansible_distribution in common_debian_variants
-
 # Ensure that we can install old software if need be.
 - name: Add edX PPA apt key
   apt_key:


### PR DESCRIPTION
This task is failing, so we are trying to remove it.

It was added 8 years ago to get GitHub version 1.7.10 or later. Presumably this is no longer needed.

3 years ago we added updating the cache, which could still potentially be needed, but hopefully not.

The error from GoCD:
```
TASK [common : Add git apt repository] *****************************************
FAILED - RETRYING: Add git apt repository (10 retries left).
FAILED - RETRYING: Add git apt repository (9 retries left).
FAILED - RETRYING: Add git apt repository (8 retries left).
FAILED - RETRYING: Add git apt repository (7 retries left).
FAILED - RETRYING: Add git apt repository (6 retries left).
FAILED - RETRYING: Add git apt repository (5 retries left).
FAILED - RETRYING: Add git apt repository (4 retries left).
FAILED - RETRYING: Add git apt repository (3 retries left).
FAILED - RETRYING: Add git apt repository (2 retries left).
FAILED - RETRYING: Add git apt repository (1 retries left).
fatal: [10.4.11.55]: FAILED! => {
    "attempts": 10,
    "changed": false
}

MSG:

failed to fetch PPA information, error was: Request failed: <urlopen error _ssl.c:1114: The handshake operation timed out>
```
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
