### PR TITLE
fix: Handle case where alternate NR license key var not set

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -24,7 +24,7 @@ fi
 # (Maybe this will keep NR trace instrumentation in place, but not cost us anything,
 # because this free-tier NR account will throw away most data.)
 # See https://github.com/edx/edx-arch-experiments/issues/692
-export NEW_RELIC_LICENSE_KEY="{{ EDXAPP_NEWRELIC_LICENSE_TEST_FREE }}"
+export NEW_RELIC_LICENSE_KEY="{{ EDXAPP_NEWRELIC_LICENSE_TEST_FREE | default('') }}"
 {% else %}
 export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% endif %}


### PR DESCRIPTION
Fixes bug in https://github.com/edx/configuration/pull/48

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
