### PR TITLE
feat: disable edxapp legacy browser in newrelic.ini.j2 for prod

### DIFF
--- a/playbooks/roles/edxapp/templates/newrelic.ini.j2
+++ b/playbooks/roles/edxapp/templates/newrelic.ini.j2
@@ -26,10 +26,6 @@
 # Transactions). This lets us do things like facet front end load time by
 # `course_id`.
 #
-{% if COMMON_ENVIRONMENT == "stage" or COMMON_DEPLOYMENT == "edge" %}
 browser_monitoring.enabled=false
 browser_monitoring.auto_instrument=false
 browser_monitoring.attributes.enabled=false
-{% else %}
-browser_monitoring.attributes.enabled=true
-{% endif %}


### PR DESCRIPTION
Disabling in stage and edge went smoothly, so this adds disabling NR legacy edxapp browser monitoring in prod as well.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
