### PR TITLE
fix: Log correct tracing headers for Datadog debugging

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -35,7 +35,7 @@ export DD_TRACE_PYMONGO_ENABLED=false
 # This might help us (or DD support) identify an interaction with incoming trace
 # headers that causes trace concatenation in edxapp.
 # See https://github.com/edx/edx-arch-experiments/issues/692
-export DD_TRACE_HEADER_TAGS=tracecontext:tracecontext,tracestate:tracestate,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
+export DD_TRACE_HEADER_TAGS=traceparent:traceparent_header,tracestate:tracestate_header,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
 # Temporary: We currently have a span (or several) for each Django middleware,
 # and Datadog Support has implied that it will be easier to debug our tracing
 # issues if we don't record those middleware. (They make up the bulk of traces,

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -46,7 +46,7 @@ export DD_TRACE_PYMONGO_ENABLED=false
 # This might help us (or DD support) identify an interaction with incoming trace
 # headers that causes trace concatenation in edxapp.
 # See https://github.com/edx/edx-arch-experiments/issues/692
-export DD_TRACE_HEADER_TAGS=tracecontext:tracecontext,tracestate:tracestate,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
+export DD_TRACE_HEADER_TAGS=traceparent:traceparent_header,tracestate:tracestate_header,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
 # Temporary: We currently have a span (or several) for each Django middleware,
 # and Datadog Support has implied that it will be easier to debug our tracing
 # issues if we don't record those middleware. (They make up the bulk of traces,

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -31,7 +31,7 @@ export DD_TRACE_PYMONGO_ENABLED=false
 # This might help us (or DD support) identify an interaction with incoming trace
 # headers that causes trace concatenation in edxapp.
 # See https://github.com/edx/edx-arch-experiments/issues/692
-export DD_TRACE_HEADER_TAGS=tracecontext:tracecontext,tracestate:tracestate,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
+export DD_TRACE_HEADER_TAGS=traceparent:traceparent_header,tracestate:tracestate_header,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
 # Temporary: We currently have a span (or several) for each Django middleware,
 # and Datadog Support has implied that it will be easier to debug our tracing
 # issues if we don't record those middleware. (They make up the bulk of traces,


### PR DESCRIPTION
- `traceparent` is the correct header, not `tracecontext`.
- Use `_header` suffix on two of these to avoid collisions with other span tags that Datadog may already be setting in other ways.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
