### PR TITLE
fix: Try disabling Mako template instrumentation in New Relic [stg/edge]

### DIFF
--- a/playbooks/roles/edxapp/templates/newrelic.ini.j2
+++ b/playbooks/roles/edxapp/templates/newrelic.ini.j2
@@ -29,3 +29,17 @@
 browser_monitoring.enabled=false
 browser_monitoring.auto_instrument=false
 browser_monitoring.attributes.enabled=false
+
+{% if COMMON_ENVIRONMENT == "stage" or COMMON_DEPLOYMENT == "edge" %}
+
+# Experiment 2024-07-22: See if instrumentation of Mako templates is
+# related to the recursive uncaught error handling problem we're
+# seeing in https://github.com/openedx/edx-platform/issues/35151
+
+[import-hook:mako.runtime]
+enabled = false
+
+[import-hook:mako.template]
+enabled = false
+
+{% endif %}


### PR DESCRIPTION
We'll deploy to prod if this looks OK.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
