### PR TITLE
fix: Don't let NR instrument mako templates in prod, either

### DIFF
--- a/playbooks/roles/edxapp/templates/newrelic.ini.j2
+++ b/playbooks/roles/edxapp/templates/newrelic.ini.j2
@@ -30,7 +30,6 @@ browser_monitoring.enabled=false
 browser_monitoring.auto_instrument=false
 browser_monitoring.attributes.enabled=false
 
-{% if COMMON_ENVIRONMENT == "stage" or COMMON_DEPLOYMENT == "edge" %}
 
 # Experiment 2024-07-22: See if instrumentation of Mako templates is
 # related to the recursive uncaught error handling problem we're
@@ -41,5 +40,3 @@ enabled = false
 
 [import-hook:mako.template]
 enabled = false
-
-{% endif %}


### PR DESCRIPTION
prod is where we actually saw the issue, so this will be the real test.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
