### PR TITLE
feat: Allow NR instrumentation of Mako templates again

### DIFF
--- a/playbooks/roles/edxapp/templates/newrelic.ini.j2
+++ b/playbooks/roles/edxapp/templates/newrelic.ini.j2
@@ -29,14 +29,3 @@
 browser_monitoring.enabled=false
 browser_monitoring.auto_instrument=false
 browser_monitoring.attributes.enabled=false
-
-
-# Experiment 2024-07-22: See if instrumentation of Mako templates is
-# related to the recursive uncaught error handling problem we're
-# seeing in https://github.com/openedx/edx-platform/issues/35151
-
-[import-hook:mako.runtime]
-enabled = false
-
-[import-hook:mako.template]
-enabled = false


### PR DESCRIPTION
This theory didn't pan out, so we're reverting the change.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
