### PR TITLE
feat: Restore Datadog tracing of pymongo

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -220,7 +220,9 @@
   when: EDXAPP_DATADOG_ENABLE
   pip:
     name:
-      - ddtrace
+      # ddtrace 2.7.9 contains a fix for a pymongo incompatibility.
+      # (Same fix is present in 2.8.2 on the 2.8.x release line.)
+      - 'ddtrace>=2.7.9'
     extra_args: "--exists-action w {{ item.extra_args|default('') }}"
     virtualenv: "{{ edxapp_venv_dir }}"
     state: present

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -28,8 +28,6 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
-# Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
-export DD_TRACE_PYMONGO_ENABLED=false
 
 # Temporary: Include span tags representing a variety of tracing HTTP headers.
 # This might help us (or DD support) identify an interaction with incoming trace

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -29,8 +29,6 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
-# Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
-export DD_TRACE_PYMONGO_ENABLED=false
 
 # Temporary: Include span tags representing a variety of tracing HTTP headers.
 # This might help us (or DD support) identify an interaction with incoming trace

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -24,8 +24,6 @@ export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
-# Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
-export DD_TRACE_PYMONGO_ENABLED=false
 
 # Temporary: Include span tags representing a variety of tracing HTTP headers.
 # This might help us (or DD support) identify an interaction with incoming trace


### PR DESCRIPTION
ddtrace 2.7.9 and 2.8.2 were released with a fix for this issue, and we've since upgraded past these.

See https://github.com/edx/edx-arch-experiments/issues/580

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
