### PR TITLE
Revert "temp: pin boto3 to 1.34.115"

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -167,7 +167,7 @@ common_pip_pkgs:
   - setuptools==44.1.0
   - virtualenv==20.2.0
   - zipp==1.2.0
-  - boto3==1.34.115
+  - boto3
   - importlib-resources==3.2.1
 
 common_web_user: www-data


### PR DESCRIPTION
Reverts edx/configuration#22 -- should no longer be needed.

See https://github.com/edx/edx-arch-experiments/issues/668

The error we had been seeing:

```
:stderr: ERROR: Could not find a version that satisfies the requirement botocore<1.35.0,>=1.34.116 (from boto3) (from versions: 0.4.1, ..., 1.34.115)
```

From discussion about reverting the pin:

> I suspect this will work because boto3/botocore 1.34.116 was just released, and there's probably a stale index not allowing the botocore dependency to be fetched. (boto3 requires the most recent botocore.)