### PR TITLE
temp: Try disabling Datadog Celery instrumentation in LMS (stage, edge)

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -47,6 +47,11 @@ export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
 # when it doesn't attempt to extract any headers.
 # See https://github.com/edx/edx-arch-experiments/issues/692
 export DD_TRACE_PROPAGATION_STYLE_EXTRACT=none
+
+# Temporary 2024-08-13: Check if celery instrumentation is causing
+# missing spans that might lead to anomalous traces.
+# https://github.com/edx/edx-arch-experiments/issues/692
+export DD_TRACE_CELERY_ENABLED=false
 {% endif %}
 
 {% endif -%}


### PR DESCRIPTION
DD support observed that in several of the anomalous traces, the request span's parent span was missing -- but that the missing span's ID showed up in logs as something celery-related.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
