### PR TITLE
revert: temp: Debugging headers for Datadog tracing

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -29,11 +29,6 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
 
-# Temporary: Include span tags representing a variety of tracing HTTP headers.
-# This might help us (or DD support) identify an interaction with incoming trace
-# headers that causes trace concatenation in edxapp.
-# See https://github.com/edx/edx-arch-experiments/issues/692
-export DD_TRACE_HEADER_TAGS=traceparent:traceparent_header,tracestate:tracestate_header,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
 # Temporary: We currently have a span (or several) for each Django middleware,
 # and Datadog Support has implied that it will be easier to debug our tracing
 # issues if we don't record those middleware. (They make up the bulk of traces,

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -30,24 +30,12 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
 
-# Temporary: Include span tags representing a variety of tracing HTTP headers.
-# This might help us (or DD support) identify an interaction with incoming trace
-# headers that causes trace concatenation in edxapp.
-# See https://github.com/edx/edx-arch-experiments/issues/692
-export DD_TRACE_HEADER_TAGS=traceparent:traceparent_header,tracestate:tracestate_header,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
 # Temporary: We currently have a span (or several) for each Django middleware,
 # and Datadog Support has implied that it will be easier to debug our tracing
 # issues if we don't record those middleware. (They make up the bulk of traces,
 # at least visually.)
 # See https://github.com/edx/edx-arch-experiments/issues/692
 export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
-
-{% if COMMON_ENVIRONMENT == "stage" or COMMON_DEPLOYMENT == "edge" %}
-# Temporary 2024-07-02: See if trace concatenation persists in Datadog
-# when it doesn't attempt to extract any headers.
-# See https://github.com/edx/edx-arch-experiments/issues/692
-export DD_TRACE_PROPAGATION_STYLE_EXTRACT=none
-{% endif %}
 
 {% endif -%}
 

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -25,11 +25,6 @@ export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
 
-# Temporary: Include span tags representing a variety of tracing HTTP headers.
-# This might help us (or DD support) identify an interaction with incoming trace
-# headers that causes trace concatenation in edxapp.
-# See https://github.com/edx/edx-arch-experiments/issues/692
-export DD_TRACE_HEADER_TAGS=traceparent:traceparent_header,tracestate:tracestate_header,x-datadog-trace-id:x-datadog-trace-id,x-datadog-parent-id:x-datadog-parent-id
 # Temporary: We currently have a span (or several) for each Django middleware,
 # and Datadog Support has implied that it will be easier to debug our tracing
 # issues if we don't record those middleware. (They make up the bulk of traces,


### PR DESCRIPTION
No longer needed for https://github.com/edx/edx-arch-experiments/issues/692

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
