### PR TITLE
chore: Setting environment var `DD_LOGS_INJECTION=true` for Django app deployments

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
@@ -36,6 +36,7 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 export DD_TRACE_LOG_STREAM_HANDLER=false
 export DD_GIT_COMMIT_SHA="{{ app_version }}"
 export DD_GIT_REPOSITORY_URL="{{ edx_django_service_repository_git_url }}"
+export DD_LOGS_INJECTION=true
 {% endif -%}
 
 export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ edx_django_service_name }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -26,6 +26,7 @@ export DD_TAGS="service:edx-edxapp-cms version:{{ app_version }}"
 export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 export DD_GIT_COMMIT_SHA="{{ app_version }}"
 export DD_GIT_REPOSITORY_URL="{{ EDXAPP_REPOSITORY_GIT_URL }}"
+export DD_LOGS_INJECTION=true
 # Copied from edx_django_service playbook for consistency; Datadog
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -27,6 +27,7 @@ export DD_TAGS="service:edx-edxapp-lms version:{{ app_version }}"
 export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 export DD_GIT_COMMIT_SHA="{{ app_version }}"
 export DD_GIT_REPOSITORY_URL="{{ EDXAPP_REPOSITORY_GIT_URL }}"
+export DD_LOGS_INJECTION=true
 # Copied from edx_django_service playbook for consistency; Datadog
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -22,6 +22,7 @@ export DD_TAGS="service:edx-edxapp-${SERVICE_VARIANT}-workers queue:${QUEUE_NAME
 export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 export DD_GIT_COMMIT_SHA="{{ app_version }}"
 export DD_GIT_REPOSITORY_URL="{{ EDXAPP_REPOSITORY_GIT_URL }}"
+export DD_LOGS_INJECTION=true
 # Copied from edx_django_service playbook for consistency; Datadog
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.

--- a/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
+++ b/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
@@ -24,6 +24,7 @@ export DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true
 export DD_TRACE_LOG_STREAM_HANDLER=false
 export DD_GIT_COMMIT_SHA="{{ app_version }}"
 export DD_GIT_REPOSITORY_URL="{{ INSIGHTS_REPOSITORY_GIT_URL }}"
+export DD_LOGS_INJECTION=true
 
 # TODO: There seems to be some potential issues enabling APM profiling in both NewRelic and Datadog.
 # A safe bet would be to enable these after NewRelic profiling is disabled.

--- a/playbooks/roles/xqueue/templates/xqueue.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue.conf.j2
@@ -17,7 +17,7 @@ directory={{ xqueue_code_dir }}
 
 # Copied DD_TRACE_LOG_STREAM_HANDLER config from edx_django_service. This is required
 # to disable Datadog trace debug logging.
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQUEUE_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true,DD_TAGS="service:{{ XQUEUE_DATADOG_APPNAME }} version:{{ app_version }}",DD_TRACE_LOG_STREAM_HANDLER=false,DD_PROFILING_ENABLED=true,DD_DATA_STREAMS_ENABLED=true,{% endif -%}PID=/var/tmp/xqueue.pid,PORT={{ xqueue_gunicorn_port }},ADDRESS={{ xqueue_gunicorn_host }},LANG={{ XQUEUE_LANG }},DJANGO_SETTINGS_MODULE=xqueue.{{ XQUEUE_SETTINGS }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQUEUE_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true,DD_TAGS="service:{{ XQUEUE_DATADOG_APPNAME }} version:{{ app_version }}",DD_TRACE_LOG_STREAM_HANDLER=false,DD_PROFILING_ENABLED=true,DD_DATA_STREAMS_ENABLED=true,DD_LOGS_INJECTION=true,{% endif -%}PID=/var/tmp/xqueue.pid,PORT={{ xqueue_gunicorn_port }},ADDRESS={{ xqueue_gunicorn_host }},LANG={{ XQUEUE_LANG }},DJANGO_SETTINGS_MODULE=xqueue.{{ XQUEUE_SETTINGS }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log

--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -17,7 +17,7 @@ directory={{ xqueue_code_dir }}
 
 # Copied DD_TRACE_LOG_STREAM_HANDLER config from edx_django_service. This is required
 # to disable Datadog trace debug logging.
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_STARTUP_TIMEOUT=10,NEW_RELIC_APP_NAME={{ XQUEUE_CONSUMER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true,DD_TAGS="service:{{ XQUEUE_CONSUMER_DATADOG_APPNAME }} version:{{ app_version }}",DD_TRACE_LOG_STREAM_HANDLER=false,DD_PROFILING_ENABLED=true,DD_DATA_STREAMS_ENABLED=true,{% endif -%}LANG={{ XQUEUE_LANG }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_STARTUP_TIMEOUT=10,NEW_RELIC_APP_NAME={{ XQUEUE_CONSUMER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true,DD_TAGS="service:{{ XQUEUE_CONSUMER_DATADOG_APPNAME }} version:{{ app_version }}",DD_TRACE_LOG_STREAM_HANDLER=false,DD_PROFILING_ENABLED=true,DD_DATA_STREAMS_ENABLED=true,DD_LOGS_INJECTION=true,{% endif -%}LANG={{ XQUEUE_LANG }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log

--- a/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
+++ b/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
@@ -21,6 +21,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 # Copied DD_TRACE_LOG_STREAM_HANDLER config from edx_django_service. This is required
 # to disable Datadog trace debug logging.
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQWATCHER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true,DD_TAGS="service:{{ XQWATCHER_DATADOG_APPNAME }} version:{{ app_version }}",DD_TRACE_LOG_STREAM_HANDLER=false,DD_PROFILING_ENABLED=true,DD_DATA_STREAMS_ENABLED=true,{% endif -%}
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQWATCHER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_HANDLER_RESOURCE_FORMAT=true,DD_TAGS="service:{{ XQWATCHER_DATADOG_APPNAME }} version:{{ app_version }}",DD_TRACE_LOG_STREAM_HANDLER=false,DD_PROFILING_ENABLED=true,DD_DATA_STREAMS_ENABLED=true,DD_LOGS_INJECTION=true,{% endif -%}
 killasgroup=true
 stopasgroup=true


### PR DESCRIPTION
This PR adds the environment variable DD_LOGS_INJECTION=true to app deployments. By enabling this setting, Python logs will can be correlated with Datadog traces, allowing for enhanced visibility and easier troubleshooting within the Datadog platform.
https://2u-internal.atlassian.net/browse/GSRE-1687

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
