### PR TITLE
docs: add comment for USE-JWT-COOKIE header

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/cors-add-header.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/cors-add-header.j2
@@ -1,6 +1,10 @@
     if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' $cors_origin;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        {# Leaving USE-JWT-COOKIE header in place, even though this could possibly be
+           cleaned up. We don't want to chance breaking ecommerce. Most backends
+           are using edx-drf-extensions>=10.2.0, and no longer use this header.
+        #}
         add_header 'Access-Control-Allow-Headers' 'Authorization, USE-JWT-COOKIE';
         {% if edx_django_service_allow_cors_credentials %}
             add_header 'Access-Control-Allow-Credentials' true;

--- a/playbooks/roles/edx_django_service_with_rendered_config/templates/edx/app/nginx/sites-available/concerns/cors-add-header.j2
+++ b/playbooks/roles/edx_django_service_with_rendered_config/templates/edx/app/nginx/sites-available/concerns/cors-add-header.j2
@@ -1,6 +1,10 @@
     if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' $cors_origin;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        {# Leaving USE-JWT-COOKIE header in place, even though this could possibly be
+           cleaned up. We don't want to chance breaking ecommerce. Most backends
+           are using edx-drf-extensions>=10.2.0, and no longer use this header.
+        #}
         add_header 'Access-Control-Allow-Headers' 'Authorization, USE-JWT-COOKIE';
         {% if edx_django_service_with_rendered_config_allow_cors_credentials %}
             add_header 'Access-Control-Allow-Credentials' true;


### PR DESCRIPTION
Although we may no longer need the USE-JWT-COOKIE
header, it could break ecommerce if this were
removed at this time. So, we are leaving
a comment so we'll see this in any searches, and
avoid updating for now.

Once all backends, including ecommerce, have edx-drf-extensions>=10.2.0, this could be removed.

See "[DEPR]: USE-JWT-COOKIE header" for more details:
- https://github.com/openedx/edx-drf-extensions/issues/371

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
