### PR TITLE
fix: Establish supervisor service dependencies on Datadog

### DIFF
--- a/playbooks/roles/supervisor/templates/etc/init/supervisor-systemd.service.j2
+++ b/playbooks/roles/supervisor/templates/etc/init/supervisor-systemd.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=supervisord - Supervisor process control system
 Documentation=http://supervisord.org
-After=network.target
+After=network.target datadog-agent.service
 
 
 [Service]


### PR DESCRIPTION
Updating the systemd unit file for the supervisor service to ensure that it starts only after the Datadog agent has been successfully initialized and stops before the Datadog agent shuts down
This will mitigate potential issues related to dropped traces by ensuring that the supervisor service stops before the Datadog agent shuts down. This allows the ddtrace run to maintain effective communication with the Datadog socket, reducing the likelihood of losing traces.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
