### PR TITLE
build: upgrade analytics data api pipeline to use Python 3.12

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -42,9 +42,7 @@ analytics_api_newrelic_appname: 'analytics-api'
 analytics_api_debian_pkgs:
   - 'libmysqlclient-dev'
 
-ANALYTICS_API_USE_PYTHON12: False
-
-ANALYTICS_API_USE_PYTHON38: True
+ANALYTICS_API_USE_PYTHON12: True
 
 ANALYTICS_API_VERSION: "master"
 ANALYTICS_API_NGINX_PORT: '1{{ analytics_api_gunicorn_port }}'

--- a/playbooks/roles/analytics_api/meta/main.yml
+++ b/playbooks/roles/analytics_api/meta/main.yml
@@ -22,7 +22,6 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python312: '{{ ANALYTICS_API_USE_PYTHON12 }}'
-    edx_django_service_use_python38: '{{ ANALYTICS_API_USE_PYTHON38 }}'
     edx_django_service_repos: '{{ ANALYTICS_API_REPOS }}'
     edx_django_service_name: '{{ analytics_api_service_name }}'
     edx_django_service_user: '{{ analytics_api_user }}'


### PR DESCRIPTION
## Description
- Upgrading `edx-analytics-data-api` service pipeline to use `Python 3.12` env 
- This will unblock all the blockers currently being faced due to upcoming `Python 3.8` end of life as most of the dependencies have started dropping support for `Python 3.8`.