### PR TITLE
fix: update virtualenv version

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -165,7 +165,7 @@ common_pip_pkgs:
   - pip=={{ COMMON_PIP_VERSION }}
   - configparser==4.0.2
   - setuptools==44.1.0
-  - virtualenv==20.2.0
+  - virtualenv==20.27.0
   - zipp==1.2.0
   - boto3
   - importlib-resources==3.2.1


### PR DESCRIPTION
---
To fix the issue with Python 3.12, upgrade the following packages to versions compatible with Python 3.12

```
1|12:02:50.288 TASK [edx_django_service : Pin pip to a specific version.] *********************
&1|12:02:50.636 fatal: [10.3.120.29]: FAILED! => {
&1|12:02:50.636     "changed": true,
&1|12:02:50.636     "cmd": [
&1|12:02:50.636         "/edx/app/analytics_api/venvs/analytics_api/bin/pip",
&1|12:02:50.636         "install",
&1|12:02:50.636         "pip==21.2.1"
&1|12:02:50.636     ],
&1|12:02:50.636     "delta": "0:00:00.117235",
&1|12:02:50.636     "end": "2024-10-18 12:02:50.601272",
&1|12:02:50.636     "rc": 1,
&1|12:02:50.636     "start": "2024-10-18 12:02:50.484037"
&1|12:02:50.636 }
&1|12:02:50.636 
&1|12:02:50.636 STDERR:
&1|12:02:50.636 
&1|12:02:50.636 Traceback (most recent call last):
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/bin/pip", line 5, in <module>
&1|12:02:50.636     from pip._internal.cli.main import main
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.12/site-packages/pip/_internal/cli/main.py", line 10, in <module>
&1|12:02:50.636     from pip._internal.cli.autocompletion import autocomplete
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.12/site-packages/pip/_internal/cli/autocompletion.py", line 9, in <module>
&1|12:02:50.636     from pip._internal.cli.main_parser import create_main_parser
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.12/site-packages/pip/_internal/cli/main_parser.py", line 7, in <module>
&1|12:02:50.636     from pip._internal.cli import cmdoptions
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.12/site-packages/pip/_internal/cli/cmdoptions.py", line 23, in <module>
&1|12:02:50.636     from pip._internal.cli.progress_bars import BAR_TYPES
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.12/site-packages/pip/_internal/cli/progress_bars.py", line 12, in <module>
&1|12:02:50.636     from pip._internal.utils.logging import get_indentation
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.12/site-packages/pip/_internal/utils/logging.py", line 18, in <module>
&1|12:02:50.636     from pip._internal.utils.misc import ensure_dir
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.12/site-packages/pip/_internal/utils/misc.py", line 21, in <module>
&1|12:02:50.636     from pip._vendor import pkg_resources
&1|12:02:50.636   File "/edx/app/analytics_api/venvs/analytics_api/lib/python3.12/site-packages/pip/_vendor/pkg_resources/__init__.py", line 58, in <module>
&1|12:02:50.636     from pip._vendor.six.moves import urllib, map, filter
&1|12:02:50.636 ModuleNotFoundError: No module named 'pip._vendor.six.moves'
&1|12:02:50.636 ```

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
