### PR TITLE
build: update npm path in edxapp pipeline

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets.j2
@@ -4,11 +4,11 @@
 {% for override in edxapp_staticfiles_storage_overrides %}
 sudo -E -H -u {{ edxapp_user }} \
     env "PATH=$PATH" "STATICFILES_STORAGE={{ override }}" \
-    {{ edxapp_venv_bin }}/npm run build && {{ edxapp_venv_bin }}/python manage.py lms collectstatic --noinput --debug-collect --settings=$EDX_PLATFORM_SETTINGS && {{ edxapp_venv_bin }}/python manage.py cms collectstatic --noinput --debug-collect --settings=$EDX_PLATFORM_SETTINGS
+    npm run build && {{ edxapp_venv_bin }}/python manage.py lms collectstatic --noinput --debug-collect --settings=$EDX_PLATFORM_SETTINGS && {{ edxapp_venv_bin }}/python manage.py cms collectstatic --noinput --debug-collect --settings=$EDX_PLATFORM_SETTINGS
 {% endfor %}
 {% else %}
 sudo -E -H -u {{ edxapp_user }} \
     env "PATH=$PATH" \
-    {{ edxapp_venv_bin }}/npm run build && {{ edxapp_venv_bin }}/python manage.py lms collectstatic --noinput --debug-collect --settings=$EDX_PLATFORM_SETTINGS && {{ edxapp_venv_bin }}/python manage.py cms collectstatic --noinput --debug-collect --settings=$EDX_PLATFORM_SETTINGS
+    npm run build && {{ edxapp_venv_bin }}/python manage.py lms collectstatic --noinput --debug-collect --settings=$EDX_PLATFORM_SETTINGS && {{ edxapp_venv_bin }}/python manage.py cms collectstatic --noinput --debug-collect --settings=$EDX_PLATFORM_SETTINGS
 {% endif %}
  


### PR DESCRIPTION
## Description
- Removed `edxapp_venv_bin` path from `npm` command to run it directly.