### PR TITLE
feat: Force use of pip3 to install python packages.

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -169,6 +169,7 @@
     name: "{{ common_pip_pkgs }}"
     state: present
     extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }}"
+    executable: pip3
   when: ansible_distribution in common_debian_variants
 
 


### PR DESCRIPTION
This should be a no-op in most cases, but for older installations where it isn't the default, forces the use.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
