### PR TITLE
build: update edx-analytics-data-api service to Python 3.11

### DIFF
--- a/playbooks/roles/analytics_api/meta/main.yml
+++ b/playbooks/roles/analytics_api/meta/main.yml
@@ -21,7 +21,7 @@
 
 dependencies:
   - role: edx_django_service
-    edx_django_service_use_python38: true
+    edx_django_service_use_python311: true
     edx_django_service_repos: '{{ ANALYTICS_API_REPOS }}'
     edx_django_service_name: '{{ analytics_api_service_name }}'
     edx_django_service_user: '{{ analytics_api_user }}'


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/851
- Updating the config for analytics-data-api to run using `Python 3.11` env.

## Testing
- Tested the change along with Python 3.11. requirements upgrade in analytics-api [PR ] on the sandbox [build](https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/64504)
- Sandbox build was successful with both these changes. 