### PR TITLE
feat: Support for Datadog Inferred Services at the library level

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -632,6 +632,10 @@ EDXAPP_XML_S3_KEY: !!null
 
 EDXAPP_DATADOG_ENABLE: "{{COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP}}"
 EDXAPP_DATADOG_PROFILING_ENABLE: "{{EDXAPP_DATADOG_ENABLE and COMMON_ENABLE_DATADOG_PROFILING}}"
+# Inferred Services allows for unification of service names for all
+# spans in the webapp and faceting metrics by service.
+# https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=python
+EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: false
 # ddtrace 2.7.9 contains a fix for a pymongo incompatibility.
 # (Same fix is present in 2.8.2 on the 2.8.x release line.)
 EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace>=2.7.9'

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -33,6 +33,10 @@ export DD_PROFILING_STACK_V2_ENABLED=true
 export DD_PROFILING_TIMELINE_ENABLED=true
 {% endif -%}
 
+{% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
+export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
+{% endif -%}
+
 export PORT="{{ edxapp_cms_gunicorn_port }}"
 export ADDRESS="{{ edxapp_cms_gunicorn_host }}"
 export LANG="{{ EDXAPP_LANG }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -34,6 +34,10 @@ export DD_PROFILING_STACK_V2_ENABLED=true
 export DD_PROFILING_TIMELINE_ENABLED=true
 {% endif -%}
 
+{% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
+export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
+{% endif -%}
+
 export PORT="{{ edxapp_lms_gunicorn_port }}"
 export ADDRESS="{{ edxapp_lms_gunicorn_host }}"
 export LANG="{{ EDXAPP_LANG }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -31,6 +31,10 @@ export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
 export DD_PROFILING_ENABLED=true
 {% endif -%}
 
+{% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
+export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
+{% endif -%}
+
 # We exec so that celery is the child of supervisor and can be managed properly
 
 exec {{ executable }} $@


### PR DESCRIPTION
Combined with agent changes, this will allow for unified service naming so that we can query DB metrics for a service.

When enabled for an environment, this change will change all spans in edxapp to use the same service name rather than integration-specific names like `service:defaultdb`.

See https://github.com/edx/edx-arch-experiments/issues/737 and https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=python

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
