### PR TITLE
feat: updated node to v20

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1124,8 +1124,8 @@ edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
 edxapp_npm_dir: "{{ edxapp_app_dir }}/.npm"
 edxapp_npm_bin: "{{ edxapp_npm_dir }}/bin"
 edxapp_settings: '{{ EDXAPP_SETTINGS }}'
-EDXAPP_NODE_VERSION: "18"
-EDXAPP_NPM_VERSION: "10.5.1"
+EDXAPP_NODE_VERSION: "20"
+EDXAPP_NPM_VERSION: "10.7.0"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp


### PR DESCRIPTION
Tracking Issue: https://github.com/edx/edx-arch-experiments/issues/727

Updated deployment to use node v20 to align with edx-platform which has also been migrated to node v20.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
