### PR TITLE
build: remove distutils in python 3.12 installation

### DIFF
--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -149,7 +149,6 @@
   apt:
     pkg:
       - python3.12-dev
-      - python3.12-distutils
     update_cache: yes
   register: install_pkgs
   until: install_pkgs is success


### PR DESCRIPTION
## Description
- `Python@3.12.8` has removed the deprecated `distutils` package from its binaries so removing this dependency to avoid breaking pipelines.