### PR TITLE
docs: Update comment for suppressing Datadog middleware spans in edxapp

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -18,11 +18,8 @@ export DD_LOGS_INJECTION=true
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
 
-# Temporary: We currently have a span (or several) for each Django middleware,
-# and Datadog Support has implied that it will be easier to debug our tracing
-# issues if we don't record those middleware. (They make up the bulk of traces,
-# at least visually.)
-# See https://github.com/edx/edx-arch-experiments/issues/692
+# Suppress middleware spans because there are about 100 for each request.
+# Remove (or set to true) for debugging.
 export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
 {% endif -%}
 

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -18,11 +18,8 @@ export DD_LOGS_INJECTION=true
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
 
-# Temporary: We currently have a span (or several) for each Django middleware,
-# and Datadog Support has implied that it will be easier to debug our tracing
-# issues if we don't record those middleware. (They make up the bulk of traces,
-# at least visually.)
-# See https://github.com/edx/edx-arch-experiments/issues/692
+# Suppress middleware spans because there are about 100 for each request.
+# Remove (or set to true) for debugging.
 export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
 
 {% endif -%}

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -18,11 +18,8 @@ export DD_LOGS_INJECTION=true
 # reason.
 export DD_TRACE_LOG_STREAM_HANDLER=false
 
-# Temporary: We currently have a span (or several) for each Django middleware,
-# and Datadog Support has implied that it will be easier to debug our tracing
-# issues if we don't record those middleware. (They make up the bulk of traces,
-# at least visually.)
-# See https://github.com/edx/edx-arch-experiments/issues/692
+# Suppress middleware spans because there are about 100 for each request.
+# Remove (or set to true) for debugging.
 export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
 {% endif -%}
 


### PR DESCRIPTION
It's now documented on the wiki as an option IDA owners may want.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
