### PR TITLE
fix: Fix django.cache service tags for Inferred Services config

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -32,6 +32,11 @@ export DD_PROFILING_TIMELINE_ENABLED=true
 
 {% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
 export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
+# Temporary: Override django.cache span service tag to match IDA name.
+# This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
+# but it's not working due to a missing `schematize_service_name` call.
+# See https://help.datadoghq.com/hc/en-us/requests/1958899
+export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-cms
 {% endif -%}
 
 export PORT="{{ edxapp_cms_gunicorn_port }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -35,7 +35,7 @@ export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
 # Temporary: Override django.cache span service tag to match IDA name.
 # This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
 # but it's not working due to a missing `schematize_service_name` call.
-# See https://help.datadoghq.com/hc/en-us/requests/1958899
+# See https://github.com/edx/edx-arch-experiments/issues/737
 export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-cms
 {% endif -%}
 

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -36,7 +36,7 @@ export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
 # Temporary: Override django.cache span service tag to match IDA name.
 # This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
 # but it's not working due to a missing `schematize_service_name` call.
-# See https://help.datadoghq.com/hc/en-us/requests/1958899
+# See https://github.com/edx/edx-arch-experiments/issues/737
 export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-lms
 {% endif -%}
 

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -33,6 +33,11 @@ export DD_PROFILING_TIMELINE_ENABLED=true
 
 {% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
 export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
+# Temporary: Override django.cache span service tag to match IDA name.
+# This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
+# but it's not working due to a missing `schematize_service_name` call.
+# See https://help.datadoghq.com/hc/en-us/requests/1958899
+export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-lms
 {% endif -%}
 
 export PORT="{{ edxapp_lms_gunicorn_port }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -33,7 +33,7 @@ export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
 # Temporary: Override django.cache span service tag to match IDA name.
 # This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
 # but it's not working due to a missing `schematize_service_name` call.
-# See https://help.datadoghq.com/hc/en-us/requests/1958899
+# See https://github.com/edx/edx-arch-experiments/issues/737
 export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-${SERVICE_VARIANT}-workers
 {% endif -%}
 

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -30,6 +30,11 @@ export DD_PROFILING_ENABLED=true
 
 {% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
 export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
+# Temporary: Override django.cache span service tag to match IDA name.
+# This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
+# but it's not working due to a missing `schematize_service_name` call.
+# See https://help.datadoghq.com/hc/en-us/requests/1958899
+export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-${SERVICE_VARIANT}-workers
 {% endif -%}
 
 # We exec so that celery is the child of supervisor and can be managed properly


### PR DESCRIPTION
This is intended as a temporary workaround until Datadog can put in a proper fix.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
