### PR TITLE
temp: enable DD_DJANGO_INSTRUMENT_MIDDLEWARE

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -20,7 +20,8 @@ export DD_TRACE_LOG_STREAM_HANDLER=false
 
 # Suppress middleware spans because there are about 100 for each request.
 # Remove (or set to true) for debugging.
-export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
+# Temporarily enabled as part of https://github.com/edx/edx-arch-experiments/issues/879
+export DD_DJANGO_INSTRUMENT_MIDDLEWARE=true
 {% endif -%}
 
 # We want to be able to toggle this on separately from DD in general.

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -20,7 +20,8 @@ export DD_TRACE_LOG_STREAM_HANDLER=false
 
 # Suppress middleware spans because there are about 100 for each request.
 # Remove (or set to true) for debugging.
-export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
+# Temporarily enabled as part of https://github.com/edx/edx-arch-experiments/issues/879
+export DD_DJANGO_INSTRUMENT_MIDDLEWARE=true
 
 {% endif -%}
 

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -20,7 +20,8 @@ export DD_TRACE_LOG_STREAM_HANDLER=false
 
 # Suppress middleware spans because there are about 100 for each request.
 # Remove (or set to true) for debugging.
-export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
+# Temporarily enabled as part of https://github.com/edx/edx-arch-experiments/issues/879
+export DD_DJANGO_INSTRUMENT_MIDDLEWARE=true
 {% endif -%}
 
 # We want to be able to toggle this on separately from DD in general.


### PR DESCRIPTION
Temporarily enabling middleware for end-of-year
to avoid deployments if an issue arises, and to
not have middleware as a blindspot.

See https://github.com/edx/edx-arch-experiments/issues/879

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
