### PR TITLE
feat: Redirect edxapp Gunicorn logs to dedicated files

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -35,6 +35,8 @@ EDXAPP_CMS_GUNICORN_EXTRA: ""
 EDXAPP_CMS_GUNICORN_EXTRA_CONF: ""
 EDXAPP_CMS_GUNICORN_TIMEOUT: 300
 
+EDXAPP_USE_GUNICORN_SEPARATE_LOG_FILE: False
+
 # Set this to the maximum number
 # of requests for gunicorn for the lms and cms
 # gunicorn --max-requests <num>
@@ -1113,6 +1115,9 @@ EDXAPP_COMPLETION_AGGREGATOR_URL: null
 edxapp_data_dir: "{{ COMMON_DATA_DIR }}/edxapp"
 edxapp_app_dir: "{{ COMMON_APP_DIR }}/edxapp"
 edxapp_log_dir: "{{ COMMON_LOG_DIR }}/edx"
+edxapp_gunicorn_log_dir: 
+  - "{{ COMMON_LOG_DIR }}/gunicorn-lms"
+  - "{{ COMMON_LOG_DIR }}/gunicorn-cms"
 edxapp_venvs_dir: "{{ edxapp_app_dir }}/venvs"
 edxapp_venv_dir: "{{ edxapp_venvs_dir }}/edxapp"
 edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -59,6 +59,18 @@
     - install
     - install:base
 
+- name: create edxapp gunicorn log dirs
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ common_web_user }}"
+    group: "{{ common_web_user }}"
+  with_items:
+    - "{{ edxapp_gunicorn_log_dir }}"
+  tags:
+    - install
+    - install:base
+
 - name: Ensure the tracking folder exists
   file:
     path: "{{ COMMON_LOG_DIR }}/tracking"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -51,4 +51,8 @@ export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }
 
 source {{ edxapp_app_dir }}/edxapp_env
 # We exec so that gunicorn is the child of supervisor and can be managed properly
+{% if EDXAPP_USE_GUNICORN_SEPARATE_LOG_FILE %}
+exec {{ executable }} -c {{ edxapp_app_dir }}/cms_gunicorn.py {{ EDXAPP_CMS_GUNICORN_EXTRA }} cms.wsgi --log-file {{ edxapp_gunicorn_log_dir[1] }}/edx.log
+{% else %}
 exec {{ executable }} -c {{ edxapp_app_dir }}/cms_gunicorn.py {{ EDXAPP_CMS_GUNICORN_EXTRA }} cms.wsgi
+{% endif %}

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -52,4 +52,8 @@ export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }
 
 source {{ edxapp_app_dir }}/edxapp_env
 # We exec so that gunicorn is the child of supervisor and can be managed properly
+{% if EDXAPP_USE_GUNICORN_SEPARATE_LOG_FILE %}
+exec {{ executable }} -c {{ edxapp_app_dir }}/lms_gunicorn.py lms.wsgi --log-file {{ edxapp_gunicorn_log_dir[0] }}/edx.log
+{% else %}
 exec {{ executable }} -c {{ edxapp_app_dir }}/lms_gunicorn.py lms.wsgi
+{% endif %}


### PR DESCRIPTION
Separate the Gunicorn stream for Gunicorn logs to ensure these logs can be explicitly assigned to the Gunicorn source in Datadog. 



---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
