### PR TITLE
build: include assets.txt in edxapp build requirements

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1764,6 +1764,7 @@ EDX_PLATFORM_VERSION: 'release'
 custom_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/custom.txt"
 base_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/base.txt"
 django_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/django.txt"
+assets_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/assets.txt"
 openstack_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/openstack.txt"
 
 sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/releases/quince.txt"
@@ -1774,6 +1775,7 @@ edxapp_requirements_files:
   - "{{ custom_requirements_file }}"
   - "{{ base_requirements_file }}"
   - "{{ django_requirements_file }}"
+  - "{{ assets_requirements_file }}"
 
 # All edxapp requirements files potentially containing Github URLs.  When using a custom
 # Github mirror, occurrences of "github.com" are replaced by the custom mirror in these


### PR DESCRIPTION
### Description
- After [Paver removal](https://github.com/openedx/edx-platform/pull/34832) from edx-platform, the pipeline started to fail 
- Added the `requirements/edx/assets.txt` file in edxapp build requirements to resolve this issue.