### PR TITLE
build: add python 3.9 to ci workflows for testing

### DIFF
--- a/.github/workflows/playbook-test.yml
+++ b/.github/workflows/playbook-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/syntax-test.yml
+++ b/.github/workflows/syntax-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Description
- `Python 3.8` has been dropped by `setup-python` action being used in CI 
- Updating CI checks to use `Python 3.9` for now but keeping the old checks for now during the review process.