### PR TITLE
temp: Enable Celery distributed tracing in stage edxapp

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -21,6 +21,14 @@ export DD_TRACE_LOG_STREAM_HANDLER=false
 # Suppress middleware spans because there are about 100 for each request.
 # Remove (or set to true) for debugging.
 export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
+
+{% if COMMON_ENVIRONMENT == "stage" %}
+# Temporary 2025-01-09: Enable Celery distributed tracing to see if it
+# has an effect on the remaining orphaned spans.
+# https://github.com/edx/edx-arch-experiments/issues/822
+export DD_CELERY_DISTRIBUTED_TRACING=true
+{% endif %}
+
 {% endif -%}
 
 # We want to be able to toggle this on separately from DD in general.

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -22,6 +22,13 @@ export DD_TRACE_LOG_STREAM_HANDLER=false
 # Remove (or set to true) for debugging.
 export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
 
+{% if COMMON_ENVIRONMENT == "stage" %}
+# Temporary 2025-01-09: Enable Celery distributed tracing to see if it
+# has an effect on the remaining orphaned spans.
+# https://github.com/edx/edx-arch-experiments/issues/822
+export DD_CELERY_DISTRIBUTED_TRACING=true
+{% endif %}
+
 {% endif -%}
 
 # We want to be able to toggle this on separately from DD in general.

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -21,6 +21,14 @@ export DD_TRACE_LOG_STREAM_HANDLER=false
 # Suppress middleware spans because there are about 100 for each request.
 # Remove (or set to true) for debugging.
 export DD_DJANGO_INSTRUMENT_MIDDLEWARE=false
+
+{% if COMMON_ENVIRONMENT == "stage" %}
+# Temporary 2025-01-09: Enable Celery distributed tracing to see if it
+# has an effect on the remaining orphaned spans.
+# https://github.com/edx/edx-arch-experiments/issues/822
+export DD_CELERY_DISTRIBUTED_TRACING=true
+{% endif %}
+
 {% endif -%}
 
 # We want to be able to toggle this on separately from DD in general.


### PR DESCRIPTION
Datadog Support suggested that we try enabling this to see if it changes anything about the orphaned spans on the edxapp workers (unexpected top-level spans that are not `operation_name:celery.run`, but instead are other spans that have lost their parent association).

Just going to enable this on stage so we don't mess with traces in prod, for now.

See https://github.com/edx/edx-arch-experiments/issues/822

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
