### PR TITLE
feat: Default Inferred Services on for edxapp

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -634,7 +634,7 @@ EDXAPP_DATADOG_PROFILING_ENABLE: "{{EDXAPP_DATADOG_ENABLE and COMMON_ENABLE_DATA
 # Inferred Services allows for unification of service names for all
 # spans in the webapp and faceting metrics by service.
 # https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=python
-EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: false
+EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: true
 # ddtrace 2.7.9 contains a fix for a pymongo incompatibility.
 # (Same fix is present in 2.8.2 on the 2.8.x release line.)
 EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace>=2.7.9'


### PR DESCRIPTION
It's on in stage, edge, and prod, but not sandboxes yet.

See https://github.com/edx/edx-arch-experiments/issues/737

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
