### PR TITLE
feat: Remove workaround for django.cache Datadog service tag in edxapp

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -40,11 +40,6 @@ export DD_PROFILING_TIMELINE_ENABLED=true
 
 {% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
 export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
-# Temporary: Override django.cache span service tag to match IDA name.
-# This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
-# but it's not working due to a missing `schematize_service_name` call.
-# See https://github.com/edx/edx-arch-experiments/issues/737
-export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-cms
 {% endif -%}
 
 export PORT="{{ edxapp_cms_gunicorn_port }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -40,11 +40,6 @@ export DD_PROFILING_TIMELINE_ENABLED=true
 
 {% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
 export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
-# Temporary: Override django.cache span service tag to match IDA name.
-# This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
-# but it's not working due to a missing `schematize_service_name` call.
-# See https://github.com/edx/edx-arch-experiments/issues/737
-export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-lms
 {% endif -%}
 
 export PORT="{{ edxapp_lms_gunicorn_port }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/worker.sh.j2
@@ -38,11 +38,6 @@ export DD_PROFILING_ENABLED=true
 
 {% if EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE %}
 export DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true
-# Temporary: Override django.cache span service tag to match IDA name.
-# This *should* be done by DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED
-# but it's not working due to a missing `schematize_service_name` call.
-# See https://github.com/edx/edx-arch-experiments/issues/737
-export DD_DJANGO_CACHE_SERVICE_NAME=edx-edxapp-${SERVICE_VARIANT}-workers
 {% endif -%}
 
 # We exec so that celery is the child of supervisor and can be managed properly


### PR DESCRIPTION
This should no longer be necessary as of Datadog 2.19.1 (tested in devstack).

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
