### PR TITLE
chore: use community.aws.ec2 module

### DIFF
--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -35,26 +35,27 @@
   when: terminate_instance == true and elb and tag_lookup.instance_ids|length == 1
 
 - name: Launch ec2 instance
-  local_action:
-    module: ec2
-    keypair: "{{ keypair }}"
-    group: "{{ security_group }}"
+  community.aws.ec2_instance:
+    key_name: "{{ keypair }}"
+    security_groups: 
+     - "{{ security_group }}"
     instance_type: "{{ instance_type }}"
     instance_initiated_shutdown_behavior: "{{ instance_initiated_shutdown_behavior }}"
-    image: "{{ ami }}"
+    image_id: "{{ ami }}"
     vpc_subnet_id: "{{ vpc_subnet_id }}"
-    assign_public_ip: yes
     wait: true
     region: "{{ region }}"
-    instance_tags: "{{ instance_tags }}"
+    tags: "{{ instance_tags }}"
+    network:
+      assign_public_ip: true
     volumes:
       - device_name: /dev/sda1
-        volume_size: "{{ root_ebs_size }}"
-        delete_on_termination: true
-        volume_type: "gp2"
-        encrypted: true
-    zone: "{{ zone }}"
-    instance_profile_name: "{{ instance_profile_name }}"
+        ebs:
+          volume_size: "{{ root_ebs_size }}"
+          delete_on_termination: true
+          volume_type: "gp2"
+          encrypted: true
+    instance_role: "{{ instance_profile_name }}"
     user_data: "{{ user_data }}"
   register: ec2
 
@@ -97,7 +98,7 @@
 - name: Add new instance to host group
   local_action:
     module: add_host
-    hostname: "{{ item.public_ip }}"
+    hostname: "{{ item.network_interfaces[0].association.public_ip }}"
     groups: launched
   with_items: "{{ ec2.instances }}"
 


### PR DESCRIPTION
The current ec2 ansible module is outdated and does not support launching a sandbox with the Ubuntu 24.04 AMI. So, I am updating the module to use the community.aws.ec2 module.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
