### PR TITLE
fix: Pin setuptools and wheel versions for Python 3.8 compatibility

### DIFF
--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -2,6 +2,8 @@
 # Core dependencies for installing other packages
 
 pip
-setuptools
-wheel
+# pinning these versions because newer versions are not available for Python 3.8. 
+# They will be unpinned once we upgrade all our Jenkins jobs to Python 3.9 or a newer version:
+setuptools==75.3.0
+wheel==0.44.0
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.45.1
+wheel==0.44.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==75.8.2
+setuptools==75.3.0
     # via -r requirements/pip.in


### PR DESCRIPTION
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
