### PR TITLE
fix: use py3.11 on analytics api

### DIFF
--- a/playbooks/roles/analytics_api/meta/main.yml
+++ b/playbooks/roles/analytics_api/meta/main.yml
@@ -21,7 +21,7 @@
 
 dependencies:
   - role: edx_django_service
-    edx_django_service_use_python38: true
+    edx_django_service_use_python311: true
     edx_django_service_repos: '{{ ANALYTICS_API_REPOS }}'
     edx_django_service_name: '{{ analytics_api_service_name }}'
     edx_django_service_user: '{{ analytics_api_user }}'


### PR DESCRIPTION
This PR puts back use of Python 3.11 per this initiative: https://github.com/edx/edx-arch-experiments/issues/851

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
