### PR TITLE
fix: Remove unneeded sandbox write access for matplotlib

### DIFF
--- a/playbooks/roles/edxapp/templates/code.sandbox.j2
+++ b/playbooks/roles/edxapp/templates/code.sandbox.j2
@@ -21,12 +21,6 @@
     /usr/lib/{{ edxapp_sandbox_python_version }}/lib-dynload/pyexpat.so mr,
     /usr/lib/{{ edxapp_sandbox_python_version }}/lib-dynload/future_builtins.so mr,
 
-    # Matplot lib  needs a place for temp caches
-    {{ edxapp_sandbox_venv_dir }}/.config/ wrix,
-    {{ edxapp_sandbox_venv_dir }}/.cache/ wrix,
-    {{ edxapp_sandbox_venv_dir }}/.config/** wrix,
-    {{ edxapp_sandbox_venv_dir }}/.cache/** wrix,
-
     # Matplotlib related libraries
     /usr/lib/{{ edxapp_sandbox_python_version }}/lib-dynload/termios.so mr,
     /usr/lib/{{ edxapp_sandbox_python_version }}/lib-dynload/parser.so mr,


### PR DESCRIPTION
See ARCHBOM-2180 for deploy timing and testing.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
