### PR TITLE
feat: add support for installing extra npm packages into edxapp

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -580,6 +580,11 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # Plugins
     - name: edx-arch-experiments==6.1.0
 
+# List of additional npm packages that should be installed into the edxapp virtual environment.
+# For more help, see:
+# https://2u-internal.atlassian.net/wiki/spaces/AT/pages/396034066/How+to+add+private+requirements+to+edx-platform
+EDXAPP_PRIVATE_NPM_REQUIREMENTS: []
+
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully
 # qualify Python classes or functions that can be used as Django middleware.

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -299,6 +299,20 @@
     - install
     - install:app-requirements
 
+# --no-save is passed as a flag to npm install to avoid saving these dependencies to package.json. Otherwise,
+# running npm install without this flag causes modifications to the package.json and package-lock.json
+# files. In turn, these modified files cause issues with working with the edxapp repository.
+- name: Install private node dependencies
+  shell: "easy_install --version && npm install --no-save {{ item.name }}"
+  with_items: "{{ EDXAPP_PRIVATE_NPM_REQUIREMENTS }}"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ edxapp_user }}"
+  when: "{{ EDXAPP_PRIVATE_NPM_REQUIREMENTS }} | length > 0"
+  tags:
+    - install
+    - install:app-requirements
+
 # The next few tasks set up the python code sandbox
 
 # need to disable this profile, otherwise the pip inside the sandbox venv has no permissions


### PR DESCRIPTION
### Description

This commit adds support for installing extra npm packages in edxapp to the `edxapp` deploy playbook. In order to add an extra npm package to edxapp, add the package to the `EDXAPP_PRIVATE_NPM_REQUIREMENTS ` list.

For more help, please see: https://2u-internal.atlassian.net/wiki/spaces/AT/pages/396034066/How+to+add+private+requirements+to+edx-platform.

**Jira**: [COSMO-683](https://2u-internal.atlassian.net/browse/COSMO-683)
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
