### PR TITLE
fix: retire EDXAPP_EXTRA_REQUIREMENTS

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -522,26 +522,18 @@ EDXAPP_UPDATE_STATIC_FILES_KEY: false
 
 EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: false
 
-# List of additional python packages that should be installed into the
-# edxapp virtual environment.
-# `name` (required), `version` (optional), and `extra_args` (optional)
-# are supported and correspond to the options of ansible's pip module.
-# Example:
-# EDXAPP_EXTRA_REQUIREMENTS:
-#   - name: mypackage
-#     version: 1.0.1
-#   - name: git+https://git.myproject.org/MyProject#egg=MyProject
+# Do NOT use EDXAPP_EXTRA_REQUIREMENTS.
+# This setting has been deprecated. Use EDXAPP_PRIVATE_REQUIREMENTS instead.
+# See argocd/applications/edxapp-lms/docs/decisions/0001-consolidate-edxapp-private-requirements.rst
 EDXAPP_EXTRA_REQUIREMENTS: []
 
-# List of private requirements that should be installed into the
-# edxapp virtual environment.
-# `name` (required), 'extra_args' (optional)
-# Example:
-# EDXAPP_PRIVATE_REQUIREMENTS:
-#   - name: git+https://git.myproject.org/MyProject#egg=MyProject
-# Note: This list contains edx.org specific dependencies, even though this is
-#  a public repo. The plan is to phase this out along with the rest of this
-#  repo as part of the DEPR https://github.com/openedx/public-engineering/issues/51.
+# These defaults for EDXAPP_PRIVATE_REQUIREMENTS are used for Edge and
+# sandboxes in EC2. Post containerization, there will be a single
+# definition of the private requirements used across all environments.
+# TODO: Sync these settings with the containerized version. See:
+# - https://github.com/edx/edx-arch-experiments/issues/1006
+# For more help, see:
+# https://2u-internal.atlassian.net/wiki/spaces/AT/pages/396034066/How+to+add+private+requirements+to+edx-platform
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
     - name: xblock-problem-builder==5.1.3
@@ -584,6 +576,11 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     # Caliper and xAPI event routing plugin
     - name: edx-event-routing-backends==5.5.6
+    # Other xblocks
+    - name: openedx-scorm-xblock==19.0.0
+
+    # Plugins
+    - name: edx-arch-experiments==6.1.0
 
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully


### PR DESCRIPTION
- Update comments to better match how to use EDXAPP_EXTRA_REQUIREMENTS and EDXAPP_PRIVATE_REQUIREMENTS.
- Add extra requirements that were installed in Edge.

Helps implement:
- https://github.com/edx/edx-arch-experiments/issues/1000

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
