### PR TITLE
fix: Remove call to print WEBPACK_CONFIG_PATH when updating static assets

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets.j2
@@ -10,12 +10,16 @@ export JS_ENV_EXTRA_CONFIG={}
 # We need to make a call to a management command before running webpack because proctoring runs a webpack
 # webworker that only gets built if the proctoring djangoapp writes out a `workers.json`:
 # https://github.com/openedx/edx-proctoring/blob/73c7f55e2be91324fa07fec6e6ac0a667fdd8412/edx_proctoring/apps.py#L4
+# We know that `print_setting` will load settings and apps, which is what we
+# actually need. Yes, this is absurd.
+
 {% if edxapp_staticfiles_storage_overrides %}
 {% for override in edxapp_staticfiles_storage_overrides %}
 export STATICFILES_STORAGE={{ override | quote }}
 sudo -E -H -u {{ edxapp_user }} \
     env "PATH=$PATH" \
-    {{ edxapp_venv_bin }}/python manage.py lms --settings=$EDX_PLATFORM_SETTINGS print_setting STATIC_ROOT WEBPACK_CONFIG_PATH \
+    echo "See comment above for why we're uselessly calling print_setting here." >/dev/null \
+    && {{ edxapp_venv_bin }}/python manage.py lms --settings=$EDX_PLATFORM_SETTINGS print_setting LMS_BASE >/dev/null \
     && npm run webpack \
     && npm run compile-sass -- --theme-dir /edx/var/edx-themes/edx-themes/edx-platform --theme-dir /edx/app/edxapp/edx-platform/themes \
     && {{ edxapp_venv_bin }}/python manage.py lms collectstatic --noinput --settings=$EDX_PLATFORM_SETTINGS \
@@ -24,7 +28,8 @@ sudo -E -H -u {{ edxapp_user }} \
 {% else %}
 sudo -E -H -u {{ edxapp_user }} \
     env "PATH=$PATH" \
-    {{ edxapp_venv_bin }}/python manage.py lms --settings=$EDX_PLATFORM_SETTINGS print_setting STATIC_ROOT WEBPACK_CONFIG_PATH \
+    echo "See comment above for why we're uselessly calling print_setting here." >/dev/null \
+    && {{ edxapp_venv_bin }}/python manage.py lms --settings=$EDX_PLATFORM_SETTINGS print_setting LMS_BASE >/dev/null \
     && npm run webpack \
     && npm run compile-sass -- --theme-dir /edx/var/edx-themes/edx-themes/edx-platform --theme-dir /edx/app/edxapp/edx-platform/themes \
     && {{ edxapp_venv_bin }}/python manage.py lms collectstatic --noinput --settings=$EDX_PLATFORM_SETTINGS \


### PR DESCRIPTION
This setting was removed from edxapp base configs in https://github.com/openedx/edx-platform/pull/36494 and one of these lines started failing with "CommandError: WEBPACK_CONFIG_PATH not found in settings."

We don't actually need to print any *particular* setting here; see comment for why we're making this call at all. So here I change it to use a setting that is more unlikely to go away any time soon.

Also, add some "comments" to help draw attention to the comment higher up, as well as a little more explanation of the situation.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
