### PR TITLE
feat: Stop blocking python_lib.zip at the nginx level in edxapp

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -100,7 +100,6 @@ error_page {{ k }} {{ v }};
 
   rewrite ^(.*)/favicon.ico$ {{ NGINX_EDXAPP_FAVICON_PATH }} last;
 
-  {% include "python_lib.zip.j2" %}
   {% include "common-settings.j2" %}
 
   location @proxy_to_cms_app {

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -130,7 +130,6 @@ error_page {{ k }} {{ v }};
 
   rewrite ^(.*)/favicon.ico$ {{ NGINX_EDXAPP_FAVICON_PATH }} last;
 
-  {% include "python_lib.zip.j2" %}
   {% include "common-settings.j2" %}
 
   {% if NGINX_EDXAPP_EMBARGO_CIDRS -%}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/python_lib.zip.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/python_lib.zip.j2
@@ -1,9 +1,0 @@
-
-  # Blackholes an archive of python library files that instructors
-  # may provide for sandboxed python problem types, the internal
-  # directive will result in nginx emitting an nginx 404. Users
-  # will not be redirected to the application 404 page.
-  location ~* python_lib.zip {
-    internal;
-  }
-


### PR DESCRIPTION
This should no longer be needed now that we have the patch currently being trialed in https://github.com/edx/edx-platform-private/pull/276

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
