### PR TITLE
feat: Add ability to install some edxapp requirements just in stage

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -580,6 +580,12 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # Plugins
     - name: edx-arch-experiments==6.1.0
 
+# This is an addendum to EDXAPP_EXTRA_REQUIREMENTS for us in installing
+# requirements only in the stage environment. (It should only be set in stage.)
+# This allows us to keep a single list of requirements that is always shared
+# between stage, prod, and edge and keep a separate list of deltas for stage.
+EDXAPP_PRIVATE_REQUIREMENTS_TESTING: []
+
 # List of additional npm packages that should be installed into the edxapp virtual environment.
 # For more help, see:
 # https://2u-internal.atlassian.net/wiki/spaces/AT/pages/396034066/How+to+add+private+requirements+to+edx-platform

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -185,10 +185,11 @@
     chdir: "{{ edxapp_code_dir }}"
   with_items:
   - "{{ EDXAPP_PRIVATE_REQUIREMENTS }}"
+  - "{{ EDXAPP_PRIVATE_REQUIREMENTS_TESTING }}"
   become_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
-  when: EDXAPP_INSTALL_PRIVATE_REQUIREMENTS
+  when: EDXAPP_INSTALL_PRIVATE_REQUIREMENTS or EDXAPP_PRIVATE_REQUIREMENTS_TESTING
   register: edxapp_install_private_python_reqs
   until: edxapp_install_private_python_reqs is succeeded
   retries: 5


### PR DESCRIPTION
This is to temporarily support a workflow that we're probably going to lose in the containerized world.

See https://github.com/edx/edx-arch-experiments/issues/1059 for more details.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
