### PR TITLE
fix: Pin version of ddtrace due to celery breakages.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -641,9 +641,10 @@ EDXAPP_DATADOG_PROFILING_ENABLE: "{{EDXAPP_DATADOG_ENABLE and COMMON_ENABLE_DATA
 # spans in the webapp and faceting metrics by service.
 # https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=python
 EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: true
-# ddtrace 2.7.9 contains a fix for a pymongo incompatibility.
-# (Same fix is present in 2.8.2 on the 2.8.x release line.)
-EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace>=2.7.9'
+
+# We are seeing issues with celery processing tasks with later versions of ddtrace,
+# so this pin is in place until we understand what's going on.
+EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace==3.8.1'
 
 EDXAPP_ORA2_FILE_PREFIX: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}/ora2'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}'


### PR DESCRIPTION
We will probably need to file a ticket with Datadog about the errors we are seeing.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
