### PR TITLE
docs: Describe a config-write failure mode

### DIFF
--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -93,6 +93,13 @@
     - install
     - install:base
 
+# This can be very hard to debug if it fails, as the `no_log` is required in
+# order to prevent app secrets from being exposed.
+#
+# Known causes to investigate when this task fails:
+#
+# - AWS secrets with malformed JSON (even ones unrelated to the service being
+#   built). Possibly also references in ansible/vars/ to nonexistent AWS secrets.
 - name: Write out app config file
   template:
     src: "config.yml.j2"


### PR DESCRIPTION
This came up recently during AU-2564.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
