### PR TITLE
Revert "chore: update assume role session duration to 4 hours"

### DIFF
--- a/util/jenkins/assume-role.sh
+++ b/util/jenkins/assume-role.sh
@@ -12,7 +12,7 @@ assume-role() {
     set +x
     ROLE_ARN="${1}"
     SESSIONID=$(date +"%s")
-    DURATIONSECONDS="${2:-14400}" # Default to 4 hours if not specified
+    DURATIONSECONDS="${2:-3600}"
 
     RESULT=(`aws sts assume-role --role-arn $ROLE_ARN \
             --role-session-name $SESSIONID \


### PR DESCRIPTION
Reverts edx/configuration#228, as it is breaking many enterprise Jenkins jobs with the error:

```An error occurred (ValidationError) when calling the AssumeRole operation: The requested DurationSeconds exceeds the MaxSessionDuration set for this role.```