### PR TITLE
fix: breaking xqueue image builds

### DIFF
--- a/docker/build/xqueue/ansible_overrides.yml
+++ b/docker/build/xqueue/ansible_overrides.yml
@@ -5,4 +5,5 @@ XQUEUE_MYSQL_HOST: "edx.devstack.mysql57"
 XQUEUE_SETTINGS: "devstack"
 xqueue_gunicorn_port: 18040
 xqueue_gunicorn_host: 0.0.0.0
+xqueue_image_building: true
 devstack: true

--- a/playbooks/roles/xqueue/defaults/main.yml
+++ b/playbooks/roles/xqueue/defaults/main.yml
@@ -207,3 +207,5 @@ xqueue_release_specific_debian_pkgs:
 xqueue_use_python3: false
 # flag to run xqueue on python3.11
 xqueue_use_python311: true
+# flag for docker builds
+xqueue_image_building: false

--- a/playbooks/roles/xqueue/tasks/main.yml
+++ b/playbooks/roles/xqueue/tasks/main.yml
@@ -17,6 +17,24 @@
     - install
     - install:system-requirements
 
+# following task is only needed for docker builds 
+- name: install pip for python3.11 for docker image
+  shell: |
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+  when: xqueue_use_python311 and xqueue_image_building
+  tags:
+    - install
+    - install:system-requirements
+
+# following task is only needed for docker builds
+- name: install virtualenv for docker image
+  shell: |
+    python3.11 -m pip install virtualenv
+  when: xqueue_use_python311 and xqueue_image_building
+  tags:
+    - install
+    - install:system-requirements
+
 - name: install python3
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
# Description 

This PR fixes jenkins build of `edxops/xqueue:latest` image. 

## Reason of breaking

There are 2 reasons of why this build was broken. 

1. Python version was updated in Xqueue from 3.8 to 3.11 (see [configruation repo PR](https://github.com/edx/configuration/pull/227) and [xqueue repo PR](https://github.com/openedx/xqueue/pull/975)) 
2. Virtualenv for docker image build was not able to perform the task i.e ([build virtualenv with python3.11](https://github.com/edx/configuration/blob/9f77eab95ae36681977a5f36e772a7ff5a367c45/playbooks/roles/xqueue/tasks/main.yml#L31)) 

## Fixes 

While [this PR](https://github.com/edx/configuration/pull/227) was able to fix python 3.8 to 3.11 issue, the issue for virtualenv still persisted and the task was failing, mostly because of version issue for virtualenv. 

As a solution I've installed virtualenv and pip separately when docker image is being built.

**NOTE:** This is only needed docker image is built and tasks are written with that condition, this is done to avoid having version conflicts with other services. Another thing to note is that the task only breaks when docker images are being built, which means that while in use with other services the virtualenv works properly, mostly because it'll get installed properly via `common` tasks. 

## Jira link 

- [BOMS-98](https://2u-internal.atlassian.net/browse/BOMS-98)

---

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG. //  (New values are added but there's no need to override them as they are written in that manner) 
  - [x] Performed the appropriate testing. // Created sandbox with this branch and tested
