### PR TITLE
fix: "Pin ddtrace to help diagnose root cause behind today's edxapp C…

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -644,7 +644,7 @@ EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: true
 
 # This constraint was set to protect against auto-upgrading to a (future)
 # major release with possible breaking changes.
-EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace<4.0.0'
+EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace=3.12.0'
 
 EDXAPP_ORA2_FILE_PREFIX: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}/ora2'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}'


### PR DESCRIPTION
Earlier this morning, we had a production incident entailing eleveated average CPU rates on edxapp hosts. This led to aggressive autoscaling, which in turn led to Mongodb failure. Rolling back from [this deployment](https://gocd.tools.edx.org/go/tab/build/detail/build_edxapp_amis/7376/run_play/1/prod_edx) to [this one](https://gocd.tools.edx.org/go/tab/build/detail/build_edxapp_amis/7375/run_play/1/prod_edx), appears to have fixed the problem.

This PR is based on the observation that there isn't any clear code change in the deployment that was rolled back to account for the heightened CPU usage. Previous experience implicates Datadog usage, and there was a minor version increase going from the last good deployment to the failing one. We pin DD tracing here to the earlier version to test this hypothesis on stage.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
