### PR TITLE
build: fix ddtrace pin format to resolve stage build failure

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -644,7 +644,7 @@ EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: true
 
 # This constraint was set to protect against auto-upgrading to a (future)
 # major release with possible breaking changes.
-EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace=3.12.0'
+EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace==3.12.0'
 
 EDXAPP_ORA2_FILE_PREFIX: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}/ora2'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}'


### PR DESCRIPTION
## Description
- Fixed the wrong syntax of constraint in edxapp default yaml file.
- `ddtrace` package was pinned yesterday in the PR https://github.com/edx/configuration/pull/235 to analyze datadog behavior but the pin syntax was not correct which caused the stage [builds](https://gocd.tools.edx.org/go/tab/build/detail/build_edxapp_amis/7380/run_play/1/stage_edx) to start failing with following error 
```
TASK [edxapp : Install Datadog APM requirements] *******************************
FAILED - RETRYING: Install Datadog APM requirements (5 retries left).
FAILED - RETRYING: Install Datadog APM requirements (4 retries left).
FAILED - RETRYING: Install Datadog APM requirements (3 retries left).
FAILED - RETRYING: Install Datadog APM requirements (2 retries left).
FAILED - RETRYING: Install Datadog APM requirements (1 retries left).
fatal: [10.3.11.39]: FAILED! => {
    "attempts": 5,
    "changed": false,
    "cmd": [
        "/edx/app/edxapp/venvs/edxapp/bin/pip3",
        "install",
        "--exists-action",
        "w",
        "ddtrace=3.12.0"
    ]
}

MSG:

:stderr: ERROR: Invalid requirement: 'ddtrace=3.12.0'
Hint: = is not a valid operator. Did you mean == ?
```