### PR TITLE
fix: pin ddtrace to incident version

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -644,7 +644,7 @@ EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: true
 
 # This constraint was set to protect against auto-upgrading to a (future)
 # major release with possible breaking changes.
-EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace==3.12.0'
+EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace==3.12.1'
 
 EDXAPP_ORA2_FILE_PREFIX: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}/ora2'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}'


### PR DESCRIPTION
Yesterday's edx production incident occurred with ddtrace at version 3.12.1. This pins to that version for additional testing on stage. Ideally, we'll see healthcheck request rates and latencies change with the bump in version

See https://github.com/edx/configuration/pull/236 for a fix to the broken syntax in yesterday's ddtrace pin.
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
