### PR TITLE
fix: Pin version of ddtrace.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -642,9 +642,10 @@ EDXAPP_DATADOG_PROFILING_ENABLE: "{{EDXAPP_DATADOG_ENABLE and COMMON_ENABLE_DATA
 # https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=python
 EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: true
 
-# This constraint was set to protect against auto-upgrading to a (future)
-# major release with possible breaking changes.
-EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace==3.12.1'
+# This constraint is in place due to a known issue with ddtrace 3.12.1 causing
+# an increase in CPU load. This can be removed once we are confident that it has been
+# resolved.
+EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace==3.12.0'
 
 EDXAPP_ORA2_FILE_PREFIX: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}/ora2'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}'


### PR DESCRIPTION
The 3.12.1 version of ddtrace is known to cause CPU load increases. Pinning until we know it's safe.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
