### PR TITLE
feat: Jenkins virtualenv hashing should vary based on args too

### DIFF
--- a/util/jenkins/virtualenv_tools.sh
+++ b/util/jenkins/virtualenv_tools.sh
@@ -2,7 +2,7 @@
 
 # function to create a virtual environment in a directory separate from
 # where it is called. Its name is predictable based on where the script
-# is called
+# is called and the args it was passed.
 #
 # . /edx/var/jenkins/jobvenvs/virtualenv_tools.sh
 # create_virtualenv --python=python3.8 --clear
@@ -36,7 +36,8 @@ function create_virtualenv () {
     fi
 
     # create a unique hash for the job based location of where job is run
-    venvname="$(pwd | md5sum | cut -d' ' -f1)"
+    # as well as the args for the virtualenv creation (includes python version)
+    venvname="$( (echo "$@"; pwd) | md5sum | cut -d' ' -f1 )"
 
     # create the virtualenv
     virtualenv "$@" "$JOBVENVDIR/$venvname"


### PR DESCRIPTION
This allows us to create a new virtualenv when the Python version changes. Otherwise, switching an invocation from Python 3.8 to 3.12 results in a broken virtualenv.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
