### PR TITLE
feat!: Add staging-specific private NPM requirements for Proctortrack

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -590,7 +590,7 @@ EDXAPP_PRIVATE_REQUIREMENTS_TESTING: []
 # For more help, see:
 # https://2u-internal.atlassian.net/wiki/spaces/AT/pages/396034066/How+to+add+private+requirements+to+edx-platform
 EDXAPP_PRIVATE_NPM_REQUIREMENTS: []
-
+EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING: []
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully
 # qualify Python classes or functions that can be used as Django middleware.
@@ -1416,7 +1416,7 @@ generic_env_config:  &edxapp_generic_env
   AWS_SES_REGION_ENDPOINT: "{{ EDXAPP_AWS_SES_REGION_ENDPOINT }}"
   FEATURES: "{{ EDXAPP_FEATURES }}"
   ##############################################
-  # Duplicating EDXAPP_FEATURES dict at config level 
+  # Duplicating EDXAPP_FEATURES dict at config level
   # For more information visit: https://2u-internal.atlassian.net/browse/BOMS-200
   # https://github.com/openedx/edx-platform/issues/37226
   AUTH_USE_OPENID_PROVIDER: "{{ EDXAPP_AUTH_USE_OPENID_PROVIDER }}"

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -597,7 +597,11 @@ EDXAPP_PRIVATE_REQUIREMENTS_TESTING: []
 # https://2u-internal.atlassian.net/wiki/spaces/AT/pages/396034066/How+to+add+private+requirements+to+edx-platform
 EDXAPP_PRIVATE_NPM_REQUIREMENTS: []
 
-# Temporary/staging-only NPM dependencies used for testing in stage
+# Private NPM dependencies used only for staging/testing purposes.
+# For each dependency added here, please include:
+# - Date added
+# - Description of why it is needed
+# - Link to the ticket for its removal
 EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING: []
 
 # List of custom middlewares that should be used in edxapp to process

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -597,11 +597,7 @@ EDXAPP_PRIVATE_REQUIREMENTS_TESTING: []
 # https://2u-internal.atlassian.net/wiki/spaces/AT/pages/396034066/How+to+add+private+requirements+to+edx-platform
 EDXAPP_PRIVATE_NPM_REQUIREMENTS: []
 
-# Private NPM dependencies used only for staging/testing purposes.
-# For each dependency added here, please include:
-# - Date added
-# - Description of why it is needed
-# - Link to the ticket for its removal
+# Temporary/staging-only NPM dependencies used for testing in stage
 EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING: []
 
 # List of custom middlewares that should be used in edxapp to process

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -590,7 +590,10 @@ EDXAPP_PRIVATE_REQUIREMENTS_TESTING: []
 # For more help, see:
 # https://2u-internal.atlassian.net/wiki/spaces/AT/pages/396034066/How+to+add+private+requirements+to+edx-platform
 EDXAPP_PRIVATE_NPM_REQUIREMENTS: []
+
+# Temporary/staging-only NPM dependencies used for testing in stage
 EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING: []
+
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully
 # qualify Python classes or functions that can be used as Django middleware.

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -312,7 +312,7 @@
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ edxapp_user }}"
-  when: EDXAPP_PRIVATE_NPM_REQUIREMENTS or EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING
+  when: (EDXAPP_PRIVATE_NPM_REQUIREMENTS | length > 0) or (EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING | length > 0)
   tags:
     - install
     - install:app-requirements

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -298,7 +298,7 @@
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ edxapp_user }}"
-  when: (EDXAPP_PRIVATE_NPM_REQUIREMENTS | length > 0) or (EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING | length > 0)
+  when: EDXAPP_PRIVATE_NPM_REQUIREMENTS or EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING
   tags:
     - install
     - install:app-requirements

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -303,7 +303,6 @@
     - install
     - install:app-requirements
 
-
 # The next few tasks set up the python code sandbox
 
 # need to disable this profile, otherwise the pip inside the sandbox venv has no permissions

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -303,16 +303,20 @@
 # --no-save is passed as a flag to npm install to avoid saving these dependencies to package.json. Otherwise,
 # running npm install without this flag causes modifications to the package.json and package-lock.json
 # files. In turn, these modified files cause issues with working with the edxapp repository.
+
 - name: Install private node dependencies
   shell: "easy_install --version && npm install --no-save {{ item.name }}"
-  with_items: "{{ EDXAPP_PRIVATE_NPM_REQUIREMENTS }}"
+  with_items:
+    - "{{ EDXAPP_PRIVATE_NPM_REQUIREMENTS }}"
+    - "{{ EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING }}"
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ edxapp_user }}"
-  when: EDXAPP_PRIVATE_NPM_REQUIREMENTS|length > 0
+  when: EDXAPP_PRIVATE_NPM_REQUIREMENTS or EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING
   tags:
     - install
     - install:app-requirements
+
 
 # The next few tasks set up the python code sandbox
 


### PR DESCRIPTION
### Context
Proctortrack is being deprecated from `edx-platform` public dependencies and migrated to internal/private installation. This PR updates the configuration repo to support staging-specific private dependency handling.

---

### Changes
- **defaults/main.yml**
  - Introduced new variable: `EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING` (empty array by default).

- **tasks/deploy.yml**
  - Updated private NPM installation task to include:
    - `EDXAPP_PRIVATE_NPM_REQUIREMENTS`
    - `EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING`
  - Conditional updated to only run when either of the arrays contain entries.

---

### Why?
- Enables staging environments to test Proctortrack installation from private repositories before rolling out to production.
- Maintains separation between staging (`_TESTING`) and production keys.

---

### Breaking Change
- Staging now uses `EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING` for Proctortrack instead of relying on `edx-platform` `package.json`.
- Consumers must override this key in their internal environment repo (`edx-internal`).

---

### Related Ticket
- https://2u-internal.atlassian.net/browse/COSMO2-117
