### PR TITLE
fix: move where ddtrace gets pinned

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -577,6 +577,12 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # Other xblocks
     - name: openedx-scorm-xblock==19.0.0
 
+    # Date: 2025-08-20
+    # We had issues with an increase in CPU with the upgrade to 3.12.1. We can unpin this when we
+    # can verify that the upgrade will not cause issues with our deployments.
+    # See ticket: https://2u-internal.atlassian.net/browse/BOMS-201
+    - name: ddtrace==3.12.0
+
     # Plugins
     - name: edx-arch-experiments==6.1.0
 
@@ -641,11 +647,6 @@ EDXAPP_DATADOG_PROFILING_ENABLE: "{{EDXAPP_DATADOG_ENABLE and COMMON_ENABLE_DATA
 # spans in the webapp and faceting metrics by service.
 # https://docs.datadoghq.com/tracing/guide/inferred-service-opt-in/?tab=python
 EDXAPP_DATADOG_INFERRED_SERVICES_ENABLE: true
-
-# This constraint is in place due to a known issue with ddtrace 3.12.1 causing
-# an increase in CPU load. This can be removed once we are confident that it has been
-# resolved.
-EDXAPP_DDTRACE_PIP_SPEC: 'ddtrace==3.12.0'
 
 EDXAPP_ORA2_FILE_PREFIX: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}/ora2'
 EDXAPP_FILE_UPLOAD_STORAGE_BUCKET_NAME: '{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}'
@@ -1416,7 +1417,7 @@ generic_env_config:  &edxapp_generic_env
   AWS_SES_REGION_ENDPOINT: "{{ EDXAPP_AWS_SES_REGION_ENDPOINT }}"
   FEATURES: "{{ EDXAPP_FEATURES }}"
   ##############################################
-  # Duplicating EDXAPP_FEATURES dict at config level 
+  # Duplicating EDXAPP_FEATURES dict at config level
   # For more information visit: https://2u-internal.atlassian.net/browse/BOMS-200
   # https://github.com/openedx/edx-platform/issues/37226
   AUTH_USE_OPENID_PROVIDER: "{{ EDXAPP_AUTH_USE_OPENID_PROVIDER }}"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -198,23 +198,6 @@
     - install
     - install:app-requirements
 
-- name: "Install Datadog APM requirements"
-  when: EDXAPP_DATADOG_ENABLE
-  pip:
-    name:
-      - "{{ EDXAPP_DDTRACE_PIP_SPEC }}"  # e.g. "ddtrace==2.8.2"
-    extra_args: "--exists-action w {{ item.extra_args|default('') }}"
-    virtualenv: "{{ edxapp_venv_dir }}"
-    state: present
-  become_user: "{{ edxapp_user }}"
-  register: edxapp_install_datadog_reqs
-  until: edxapp_install_datadog_reqs is succeeded
-  retries: 5
-  delay: 15
-  tags:
-    - install
-    - install:app-requirements
-
 # Pulling Atlas translations into the repo needs to happen after
 # Python dependencies have been installed. Note: This task leaves the
 # git working directory in a "dirty" state.


### PR DESCRIPTION
Removed `EDXAPP_DDTRACE_PIP_SPEC` and
moved ddtrace as a default dependency
in `EDXAPP_PRIVATE_REQUIREMENTS`.

Temporary pin for `ddtrace==3.12.0`
was moved as well. Back-dated new pin
with 2025-08-20, the same date used in
`edx-internals` comments for same pin.

Testing instructions:
- Datadog was tested on a sandbox, which uses the default
`EDXAPP_PRIVATE_REQUIREMENTS` from configuration,
as does Edge.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
