### PR TITLE
fix: update pip installation to use requirements files

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -128,12 +128,15 @@
     - install
     - install:app-requirements
 
-- name: Pin pip to a specific version.
-  command: "{{ edxapp_venv_dir }}/bin/pip install pip=={{ COMMON_PIP_VERSION }}"
+- name: Install pip and pip-tools requirements
+  command: "{{ edxapp_venv_dir }}/bin/pip install -r requirements/{{ item }}"
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ edxapp_user }}"
   environment: "{{ edxapp_environment }}"
+  with_items:
+    - pip.txt
+    - pip-tools.txt
   tags:
     - install
     - install:app-requirements


### PR DESCRIPTION
Description:
This PR is been raised in order to support the changes for below PR:

- https://github.com/openedx/edx-platform/pull/37309

Firstly, in order to support above PR, I went ahead and updated the COMMON_PIP_VERSION to 25.0.1 and to test with these change, started the sandbox build. It failed with below error:

`pip install celery==4.4.7
Collecting celery==4.4.7
  Downloading celery-4.4.7-py2.py3-none-any.whl.metadata (19 kB)
WARNING: Ignoring version 4.4.7 of celery since it has invalid metadata:
Requested celery==4.4.7 from https://files.pythonhosted.org/packages/c8/0c/609e3611d20c9f8d883852d1be5516671f630fb08c8c1e56911567dfba7b/celery-4.4.7-py2.py3-none-any.whl has invalid metadata: Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
    pytz (>dev)
         ~^
Please use pip<24.1 if you need to use this version.
ERROR: Ignored the following yanked versions: 5.0.6, 5.2.5
ERROR: Could not find a version that satisfies the requirement celery==4.4.7 (from versions: 0.1.2, 0.1.4, 0.1.6, 0.1.7, 0.1.8, 0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15, 0.2.0, 0.3.0, 0.3.7, 0.3.20, 0.4.0, 0.4.1, 0.6.0, 0.8.0, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.2.0, 2.2.1, 2.2.2, 2.2.3, 2.2.4, 2.2.5, 2.2.6, 2.2.7, 2.2.8, 2.2.9, 2.2.10, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.3.5, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.4.5, 2.4.6, 2.4.7, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.5.5, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5, 3.0.6, 3.0.7, 3.0.8, 3.0.9, 3.0.10, 3.0.11, 3.0.12, 3.0.13, 3.0.14, 3.0.15, 3.0.16, 3.0.17, 3.0.18, 3.0.19, 3.0.20, 3.0.21, 3.0.22, 3.0.23, 3.0.24, 3.0.25, 3.1.0, 3.1.1, 3.1.2, 3.1.3, 3.1.4, 3.1.5, 3.1.6, 3.1.7, 3.1.8, 3.1.9, 3.1.10, 3.1.11, 3.1.12, 3.1.13, 3.1.14, 3.1.15, 3.1.16, 3.1.17, 3.1.18, 3.1.19, 3.1.20, 3.1.21, 3.1.22, 3.1.23, 3.1.24, 3.1.25, 3.1.26.post1, 3.1.26.post2, 4.0.0rc3, 4.0.0rc4, 4.0.0rc5, 4.0.0rc6, 4.0.0rc7, 4.0.0, 4.0.1, 4.0.2, 4.1.0, 4.1.1, 4.2.0rc1, 4.2.0rc2, 4.2.0rc3, 4.2.0rc4, 4.2.0, 4.2.1, 4.2.2, 4.3.0rc1, 4.3.0rc2, 4.3.0rc3, 4.3.0, 4.3.1, 4.4.0rc1, 4.4.0rc2, 4.4.0rc3, 4.4.0rc4, 4.4.0rc5, 4.4.0, 4.4.1, 4.4.2, 4.4.3, 4.4.4, 4.4.5, 4.4.6, 4.4.7, 5.0.0a1, 5.0.0a2, 5.0.0b1, 5.0.0rc1, 5.0.0rc2, 5.0.0rc3, 5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.1.0b1, 5.1.0b2, 5.1.0rc1, 5.1.0, 5.1.1, 5.1.2, 5.2.0b1, 5.2.0b2, 5.2.0b3, 5.2.0rc1, 5.2.0rc2, 5.2.0, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.6, 5.2.7, 5.3.0a1, 5.3.0b1, 5.3.0b2, 5.3.0rc1, 5.3.0rc2, 5.3.0, 5.3.1, 5.3.4, 5.3.5, 5.3.6, 5.4.0rc1, 5.4.0rc2, 5.4.0, 5.5.0b1, 5.5.0b2, 5.5.0b3, 5.5.0b4, 5.5.0rc1, 5.5.0rc2, 5.5.0rc3, 5.5.0rc4, 5.5.0rc5, 5.5.0, 5.5.1, 5.5.2, 5.5.3)
ERROR: No matching distribution found for celery==4.4.7`

This error talks about the celery version which ecommerce repo is using is not compatible with the pip version which we changed.


So, instead of changing COMMON_PIP_VERSION
 
we changed the edxapp role only, and installed the pip and pip tools files first.
 
With this change we ensure that we are on the version that edx-platform is on (prior to these changes, it may or may not be the same as the task installs common pip version)
 
We also ensure that we don't break other services, by changing Common version.
 
As edx-platform PR is waiting on our side to test and merge, we can either dive deep into fixing ecommerce celery issue, or create another variable and go down that route that each service starts using it's own pip version. This approach seems like a good middle ground which would allow us and edx-platform to remove blocker from our side giving us time to later experiment with variable for each service or deep dive into fixing ecommerce


### JIRA ticket
https://2u-internal.atlassian.net/browse/BOMS-195

### Sandbox build link:
https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/69230/