### PR TITLE
fix: update Node.js and npm versions to 24 and 11.5.1

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1135,8 +1135,8 @@ edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
 edxapp_npm_dir: "{{ edxapp_app_dir }}/.npm"
 edxapp_npm_bin: "{{ edxapp_npm_dir }}/bin"
 edxapp_settings: '{{ EDXAPP_SETTINGS }}'
-EDXAPP_NODE_VERSION: "20"
-EDXAPP_NPM_VERSION: "10.7.0"
+EDXAPP_NODE_VERSION: "24"
+EDXAPP_NPM_VERSION: "11.5.1"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp


### PR DESCRIPTION
### Description:
This PR is inline with the edx-platform PR https://github.com/openedx/edx-platform/pull/37166 where the node version is upgraded to 24.

This PR contains:

- Node.js version updated from "20" to "24"
- npm version updated from "10.7.0" to "11.5.1"

### JIRA Link:
https://2u-internal.atlassian.net/browse/BOMS-213

### Sandbox build link:
https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/69290/