### PR TITLE
fix: remove ddtrace pin

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -577,11 +577,9 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # Other xblocks
     - name: openedx-scorm-xblock==19.0.0
 
-    # Date: 2025-08-20
-    # We had issues with an increase in CPU with the upgrade to 3.12.1. We can unpin this when we
-    # can verify that the upgrade will not cause issues with our deployments.
-    # See ticket: https://2u-internal.atlassian.net/browse/BOMS-201
-    - name: ddtrace==3.12.0
+    # This constraint was added to protect against auto-upgrading to a (future)
+    # major release with possible breaking changes.
+    - name: ddtrace<4.0.0
 
     # Plugins
     - name: edx-arch-experiments==6.1.0

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -577,6 +577,12 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # Other xblocks
     - name: openedx-scorm-xblock==19.0.0
 
+    # Date: 2025-08-20
+    # We had issues with an increase in CPU with the upgrade to 3.12.1. We can unpin this when we
+    # can verify that the upgrade will not cause issues with our deployments.
+    # See ticket: https://2u-internal.atlassian.net/browse/BOMS-201
+    - name: ddtrace==3.12.0
+
     # Plugins
     - name: edx-arch-experiments==6.1.0
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -577,12 +577,6 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # Other xblocks
     - name: openedx-scorm-xblock==19.0.0
 
-    # Date: 2025-08-20
-    # We had issues with an increase in CPU with the upgrade to 3.12.1. We can unpin this when we
-    # can verify that the upgrade will not cause issues with our deployments.
-    # See ticket: https://2u-internal.atlassian.net/browse/BOMS-201
-    - name: ddtrace==3.12.0
-
     # Plugins
     - name: edx-arch-experiments==6.1.0
 


### PR DESCRIPTION
We had issues with an increase in CPU with
the upgrade to ddtrace 3.12.1. It has been
fixed in ddtrace 3.12.5, so we are unpinning.

See ticket:
https://2u-internal.atlassian.net/browse/BOMS-201

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
