### PR TITLE
temp: fix npm installation dependency

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -283,11 +283,8 @@
     - install
     - install:app-requirements
 
-# --no-save is passed as a flag to npm install to avoid saving these dependencies to package.json. Otherwise,
-# running npm install without this flag causes modifications to the package.json and package-lock.json
-# files. In turn, these modified files cause issues with working with the edxapp repository.
 - name: Install private node dependencies
-  shell: "easy_install --version && npm install --no-save {{ item.name }}"
+  shell: "easy_install --version && npm install {{ item.name }}"
   with_items: "{{ EDXAPP_PRIVATE_NPM_REQUIREMENTS }}"
   args:
     chdir: "{{ edxapp_code_dir }}"


### PR DESCRIPTION
# Description 
This PR adds a change to remove `--no-save` param in `npm install` command over [here](https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/tasks/deploy.yml#L294) 

This is a temp change so that pipelines can be unblocked.

Related NPM issue link : https://github.com/npm/cli/issues/1460

## Reasoning
When npm install is ran with `--no-save` it behaves a bit different 

- `npm install --no-save package_1`
- `npm install --no-save package_2` 

Package_2 will get installed and Package_1 will get removed. 

 
Here are the logs of the commands
 
```
npm install --no-save @edx/brand-edx.org@^2.1.3
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'karma@0.13.22',
npm warn EBADENGINE   required: { node: '0.10 || 0.12 || 4 || 5' },
npm warn EBADENGINE   current: { node: 'v20.19.5', npm: '10.7.0' }
npm warn EBADENGINE }
 
added 1 package, and audited 1684 packages in 3s
 
```
This is dry run fired after installing brand
 
```
npm install --no-save git+[https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e…](https://git@github.com/anupdhabarde/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e529ea8732) --dry-run
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'karma@0.13.22',
npm warn EBADENGINE   required: { node: '0.10 || 0.12 || 4 || 5' },
npm warn EBADENGINE   current: { node: 'v20.19.5', npm: '10.7.0' }
npm warn EBADENGINE }
 
remove @edx/brand-edx.org 2.1.3
 
removed 1 package in 2s
```
 
Which shows that if we use --no-save the lastest package install will remove the older package.
 
For now the removal is done, but we are not sure if we should keep it or not because of these comments.
 
[https://github.com/edx/configuration/blob/e6f312fdcb173eeced30348ae08efacc4a5e95b7/playbooks/roles/…](https://github.com/edx/configuration/blob/e6f312fdcb173eeced30348ae08efacc4a5e95b7/playbooks/roles/edxapp/tasks/deploy.yml#L289-L291)
 
Which was added during this PR : https://github.com/edx/configuration/pull/188

## Relevant Slack Thread
https://twou.slack.com/archives/C048NH9K5BN/p1758110750946189