### PR TITLE
fix: add --no-save again to npm installs

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -287,11 +287,16 @@
     - install:app-requirements
 
 
-- name: Install private node dependencies
-  shell: "easy_install --version && npm install {{ item.name }}"
-  with_items:
-    - "{{ EDXAPP_PRIVATE_NPM_REQUIREMENTS }}"
-    - "{{ EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING }}"
+
+- name: Install private node dependencies in one command
+  shell: "easy_install --version && npm install --no-save {{ all_npm_packages | join(' ') }}"
+  vars:
+    all_npm_packages: >-
+      {{
+        (EDXAPP_PRIVATE_NPM_REQUIREMENTS + EDXAPP_PRIVATE_NPM_REQUIREMENTS_TESTING)
+        | map(attribute='name')
+        | list
+      }}
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ edxapp_user }}"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -288,7 +288,10 @@
 
 # --no-save is passed as a flag to npm install to avoid saving these dependencies to package.json. Otherwise,
 # running npm install without this flag causes modifications to the package.json and package-lock.json
-# files. In turn, these modified files cause issues with working with the edxapp repository.
+# files. In turn, these modified files cause issues with working with the edxapp repository because,
+# while doing the setup "checkout edx-platform repo into {{ edxapp_code_dir }}" fails.
+# This only fails in sandbox, prod and stg are fine without this change (--no-save)
+#
 # See https://github.com/edx/configuration/pull/256 for more details.
 
 - name: Install private node dependencies

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -286,9 +286,12 @@
     - install
     - install:app-requirements
 
+# --no-save is passed as a flag to npm install to avoid saving these dependencies to package.json. Otherwise,
+# running npm install without this flag causes modifications to the package.json and package-lock.json
+# files. In turn, these modified files cause issues with working with the edxapp repository.
+# See https://github.com/edx/configuration/pull/256 for more details.
 
-
-- name: Install private node dependencies in one command
+- name: Install private node dependencies
   shell: "easy_install --version && npm install --no-save {{ all_npm_packages | join(' ') }}"
   vars:
     all_npm_packages: >-


### PR DESCRIPTION
# Description 
This PR adds `--no-save` back to private npm installs. And changes the method of installation to install in one command/one go, rather than looping through the items. 

Details of why `--no-save` was removed are present here : https://github.com/edx/configuration/pull/255 

Relevant slack thread on why it was removed: https://twou.slack.com/archives/C048NH9K5BN/p1758110750946189

## Reasoning 

The reason behind adding it back is that without `--no-save` there will be changes in `package.json` and `package-lock.json` which will fail the [checkout edx-platform repo](https://github.com/edx/configuration/blob/1b2990bff995dbea08081838a175b5817c314675/playbooks/roles/edxapp/tasks/deploy.yml#L49) task, causing deployment failures in sandbox with this error `Local modifications exist in repository (force=no)`. 

Failing sandbox link :- https://tools-edx-jenkins.edx.org/job/sandboxes/job/CreateSandbox/69475/console

## Fixes 

Here we have fixed the issue by 
- Combining both variables and joining them so the issue in https://github.com/edx/configuration/pull/255  is not repeated 
- Bringing back `--no-save` so sandboxes don't fail

Passing sandbox link :- https://tools-edx-jenkins.edx.org/job/sandboxes/job/CreateSandbox/69477/console

## Jira link 

[BOMS-232](https://2u-internal.atlassian.net/browse/BOMS-232)
---

Make sure that the following steps are done before merging:

  - [x] Performed the appropriate testing.   
