### PR TITLE
feat: update ansible release to jammy

### DIFF
--- a/playbooks/jenkins_data_engineering_new.yml
+++ b/playbooks/jenkins_data_engineering_new.yml
@@ -23,7 +23,7 @@
     COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE: True
     COMMON_SECURITY_UPDATES: yes
     SECURITY_UPGRADE_ON_ANSIBLE: true
-    ansible_distribution_release: focal
+    ansible_distribution_release: jammy
 
   roles:
     - role: aws


### PR DESCRIPTION
Updates `ansible_distribution_release` from `focal` -> `jammy`. 

This impacts the python package installed here (`python3.5-dev` -> `python3.8`):

https://github.com/edx/configuration/blob/612213fa875b8175c483d56df6ec14e3bc550e62/playbooks/roles/common_vars/defaults/main.yml#L150
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
