### PR TITLE
fix: Remove python 3.5 from common package install

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -142,8 +142,7 @@ common_release_specific_debian_pkgs:
   bionic:
     - python-pip
     - python3.5-dev
-  focal:
-    - python3.5-dev
+  focal: []
   jammy:
     - python3.8
 


### PR DESCRIPTION
edxapp builds are failing because Python 3.5 isn't present in the deadsnakes PPA (I assume recently removed), so this task is erroring out: `common : Install role-independent useful system packages`

I'm not aware of anything still relying on 3.5 (I think it's all 3.8 through 3.12) so let's just remove it from this list.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
