### PR TITLE
fix: Use python2.7-minimal instead of python-minimal

### DIFF
--- a/playbooks/roles/python/defaults/main.yml
+++ b/playbooks/roles/python/defaults/main.yml
@@ -1,4 +1,4 @@
 # Install python2.7 + the /usr/bin/python symlink.
 
 python_packages:
-  - python-minimal
+  - python2.7-minimal


### PR DESCRIPTION
`python-minimal` is not in Ubuntu 22.04, so we need to install `python2.7-minimal` instead. (Unclear if this causes problems for older versions of Ubuntu.)

BOMS-238

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
