### PR TITLE
fix: Use correct IPython package for Jammy

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1821,7 +1821,7 @@ edxapp_release_specific_debian_pkgs:
   focal:
     - ipython3
   jammy:
-    - python3-ipython3
+    - ipython3
 
 edxapp_debian_pkgs_default: "{{ edxapp_debian_pkgs + edxapp_release_specific_debian_pkgs[ansible_distribution_release] }}"
 


### PR DESCRIPTION
`python3-ipython` is the backend, but `ipython3` also contains the frontend.

BOMS-238

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
