### PR TITLE
feat: Install vendored Python 3.11 for edxapp under Ubuntu focal

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -15,6 +15,41 @@
 
 EDXAPP_PYTHON_VERSION: "python3.11"
 
+# Enable installing Python 3.11 on out-of-support Ubuntu. These packages are built
+# using the deadsnakes py3.11 repo and runbook and then uploaded to S3.
+use_vendored_py311: true
+# S3 bucket name -- set in edx-internal and edge-internal
+VENDORED_PYTHON_BUCKET: "SET ME"
+# Folder path in S3 bucket, containing deb files
+vendored_py311_folder: "python-debs/deadsnakes-3.11.13-15-g8adac492d4-1+focal1-build-20251003"
+# Build string that's present in the deb file names.
+vendored_py311_build: "3.11.13-15-g8adac492d4-1+focal1"
+# These must be kept topologically sorted, dependant packages last, as they
+# will be installed one at a time.
+#
+# The only packages we actually want are python3.11-dev and python3.11-distutils
+# but we need to include all of their dependencies first.
+vendored_py311_pkgs:
+- "libpython3.11-minimal_{{ vendored_py311_build }}_amd64.deb"
+- "python3.11-lib2to3_{{ vendored_py311_build }}_all.deb"
+- "python3.11-minimal_{{ vendored_py311_build }}_amd64.deb"
+- "python3.11-distutils_{{ vendored_py311_build }}_all.deb"
+- "libpython3.11-stdlib_{{ vendored_py311_build }}_amd64.deb"
+- "python3.11_{{ vendored_py311_build }}_amd64.deb"
+- "libpython3.11_{{ vendored_py311_build }}_amd64.deb"
+- "libpython3.11-dev_{{ vendored_py311_build }}_amd64.deb"
+- "python3.11-dev_{{ vendored_py311_build }}_amd64.deb"
+# Packages that are needed for installing the above, but that can be found in
+# the regular Ubuntu repositories.
+py311_dependencies:
+- libssl1.1
+- libexpat1
+- libexpat1-dev
+- mime-support
+- tzdata
+- libreadline8
+- libsqlite3-0
+
 # Bucket used for xblock file storage
 EDXAPP_XBLOCK_FS_STORAGE_BUCKET: !!null
 EDXAPP_XBLOCK_FS_STORAGE_PREFIX: !!null

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -179,6 +179,7 @@
     - install:base
 
 - name: install python3.11
+  when: not use_vendored_py311
   apt:
     pkg:
       - python3.11-dev
@@ -188,6 +189,44 @@
   until: install_pkgs is success
   retries: 10
   delay: 5
+  tags:
+    - install
+    - install:system-requirements
+
+- name: "Directory for vendored Python 3.11 packages"
+  when: use_vendored_py311
+  file:
+    path: "/tmp/vendored_python_{{ vendored_py311_build }}"
+    state: directory
+  tags:
+    - install
+    - install:system-requirements
+
+- name: "Download vendored Python 3.11 packages"
+  when: use_vendored_py311
+  aws_s3:
+    mode: get
+    bucket: "{{ VENDORED_PYTHON_BUCKET }}"
+    object: "{{ vendored_py311_folder }}/{{ item }}"
+    dest: "/tmp/vendored_python_{{ vendored_py311_build }}/{{ item }}"
+  with_items: "{{ vendored_py311_pkgs }}"
+  tags:
+    - install
+    - install:system-requirements
+
+- name: "Install dependencies for Python 3.11"
+  when: use_vendored_py311
+  apt:
+    pkg: "{{ py311_dependencies }}"
+    update_cache: yes
+  tags:
+    - install
+    - install:system-requirements
+
+- name: "Install vendored Python 3.11 packages"
+  when: use_vendored_py311
+  command: dpkg -i "/tmp/vendored_python_{{ vendored_py311_build }}/{{ item }}"
+  with_items: "{{ vendored_py311_pkgs }}"
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
Workaround for Focal EOL in deadsnakes. See BOMS-239.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
