### PR TITLE
feat: Download vendored py3.11 files from GH instead of S3

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -16,13 +16,15 @@
 EDXAPP_PYTHON_VERSION: "python3.11"
 
 # Enable installing Python 3.11 on out-of-support Ubuntu. These packages are built
-# using the deadsnakes py3.11 repo and runbook and then uploaded to S3.
+# using the deadsnakes py3.11 repo and runbook.
 use_vendored_py311: true
-# S3 bucket name -- set in edx-internal and edge-internal
-VENDORED_PYTHON_BUCKET: "SET ME"
-# Folder path in S3 bucket, containing deb files
-vendored_py311_folder: "python-debs/deadsnakes-3.11.13-15-g8adac492d4-1+focal1-build-20251003"
-# Build string that's present in the deb file names.
+# Base URL for deb packages.
+#
+# For repeatability, this is locked to a specific commit on the `vendored`
+# branch.
+vendored_py311_url_base: "https://raw.githubusercontent.com/edx/configuration/343b014de1577e02160a0dddce92da4078ae7a37/vendored/py3.11-focal"
+# Build string that's present in the deb file names. (Just used to make the
+# names below easier to read.)
 vendored_py311_build: "3.11.13-15-g8adac492d4-1+focal1"
 # These must be kept topologically sorted, dependant packages last, as they
 # will be installed one at a time.

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -204,11 +204,10 @@
 
 - name: "Download vendored Python 3.11 packages"
   when: use_vendored_py311
-  aws_s3:
-    mode: get
-    bucket: "{{ VENDORED_PYTHON_BUCKET }}"
-    object: "{{ vendored_py311_folder }}/{{ item }}"
+  get_url:
+    url: "{{ vendored_py311_url_base }}/{{ item|urlencode }}"
     dest: "/tmp/vendored_python_{{ vendored_py311_build }}/{{ item }}"
+    timeout: 60
   with_items: "{{ vendored_py311_pkgs }}"
   tags:
     - install


### PR DESCRIPTION
New approach for BOMS-239, since S3 permissions were causing problems.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
