### PR TITLE
fix: changes the pip version compatible with python 2.7

### DIFF
--- a/docker/build/analytics_pipeline/Dockerfile
+++ b/docker/build/analytics_pipeline/Dockerfile
@@ -29,7 +29,7 @@ ENV BOTO_CONFIG=/dev/null \
     ANALYTICS_PIPELINE_VENV=/edx/app/analytics_pipeline/venvs \
     BOOTSTRAP=/etc/bootstrap.sh \
     COMMON_BASE_DIR=/edx \
-    COMMON_PIP_PACKAGES_PIP='pip==21.2.1' \
+    COMMON_PIP_PACKAGES_PIP='pip==20.3.4' \
     COMMON_PIP_PACKAGES_SETUPTOOLS='setuptools==44.1.0' \
     COMMON_PIP_PACKAGES_VIRTUALENV='virtualenv==20.1.0' \
     COMMON_MYSQL_READ_ONLY_USER='read_only' \


### PR DESCRIPTION
### Description:
Docker build for analytics pipeline was failing because it attempted to install `pip==21.2.1` on Python 2.7, but pip versions 21.0+ dropped support for Python 2.7.

### Solution:
Updated `COMMON_PIP_PACKAGES_PIP` from `pip==21.2.1` to `pip==20.3.4` (the last pip version supporting Python 2.7) in the analytics pipeline Dockerfile.

### Job:
[Docker-analytics-pipeline-image-builder](https://tools-edx-jenkins.edx.org/job/DockerCI/job/image-builders/job/analytics_pipeline-image-builder/)

### Build successful:
<img width="1140" height="929" alt="Screenshot 2025-10-08 011133" src="https://github.com/user-attachments/assets/2c94944f-e235-4749-9ca4-1aa9de62efe5" />

### Jira ticket:
[BOMS-196](https://2u-internal.atlassian.net/browse/BOMS-196)