### PR TITLE
fix: Update STATIC_ROOT retrieval method

### DIFF
--- a/playbooks/continuous_delivery/upload_assets.yml
+++ b/playbooks/continuous_delivery/upload_assets.yml
@@ -28,9 +28,9 @@
     SUB_APPLICATION_NAME: "lms"
     COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; {{ APPLICATION_PATH }}/venvs/{{ APPLICATION_NAME }}/bin/python /edx/bin/manage.{{ APPLICATION_NAME }}"
     STATIC_ROOT: >-
-      $({{ COMMAND_PREFIX }} print_setting STATIC_ROOT | tail -n1)
+      $({{ COMMAND_PREFIX }} shell --command "from django.conf import settings; print(getattr(settings, 'STATIC_ROOT', ''))" | tail -n1)
     STATIC_ROOT_EDXAPP: >-
-      $({{ COMMAND_PREFIX }} {{ SUB_APPLICATION_NAME }} print_setting STATIC_ROOT --settings="{{ EDX_PLATFORM_SETTINGS }}" | tail -n1)
+      $({{ COMMAND_PREFIX }} {{ SUB_APPLICATION_NAME }} shell --settings "{{ EDX_PLATFORM_SETTINGS }}" --command "from django.conf import settings; print(getattr(settings, 'STATIC_ROOT', ''))" | tail -n1)
   gather_facts: False
   become: True
   tasks:

--- a/playbooks/continuous_delivery/upload_assets.yml
+++ b/playbooks/continuous_delivery/upload_assets.yml
@@ -28,9 +28,9 @@
     SUB_APPLICATION_NAME: "lms"
     COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; {{ APPLICATION_PATH }}/venvs/{{ APPLICATION_NAME }}/bin/python /edx/bin/manage.{{ APPLICATION_NAME }}"
     STATIC_ROOT: >-
-      $({{ COMMAND_PREFIX }} shell --command "from django.conf import settings; print(getattr(settings, 'STATIC_ROOT', ''))")
+      $({{ COMMAND_PREFIX }} print_setting STATIC_ROOT | tail -n1)
     STATIC_ROOT_EDXAPP: >-
-      $({{ COMMAND_PREFIX }} {{ SUB_APPLICATION_NAME }} shell --settings "{{ EDX_PLATFORM_SETTINGS }}" --command "from django.conf import settings; print(getattr(settings, 'STATIC_ROOT', ''))")
+      $({{ COMMAND_PREFIX }} {{ SUB_APPLICATION_NAME }} print_setting STATIC_ROOT --settings="{{ EDX_PLATFORM_SETTINGS }}" | tail -n1)
   gather_facts: False
   become: True
   tasks:


### PR DESCRIPTION
# Description 
 Add | tail -n1 to the existing shell --command approach to filter the output and extract only the last line (the actual path), removing any warnings that appear before it.

Changes:

```
STATIC_ROOT: Added | tail -n1 to filter output from shell --command
STATIC_ROOT_EDXAPP: Added | tail -n1 to filter output from shell --command
```
Why this approach: This is a minimal change that preserves the existing command structure while adding simple output filtering. The tail -n1 command extracts only the last line of stdout (the path), filtering out any Django startup warnings that appear on previous lines.

# Related Ticket
https://2u-internal.atlassian.net/browse/BOMS-243