### PR TITLE
fix: install vendored python 3.11 on ubuntu focal for analytics api

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -13,10 +13,6 @@
 
 ANALYTICS_API_GIT_IDENTITY: !!null
 
-# Upgrading to python 3.12, let's leave 3.11 out of the image as it's preventing the image from building.
-edx_django_service_use_python311: false
-edx_django_service_use_python312: true
-
 #
 # vars are namespace with the module name
 #

--- a/playbooks/roles/analytics_api/meta/main.yml
+++ b/playbooks/roles/analytics_api/meta/main.yml
@@ -21,7 +21,8 @@
 
 dependencies:
   - role: edx_django_service
-    edx_django_service_use_python311: true
+    edx_django_service_use_python311: false
+    edx_django_service_use_vendored_py311: true
     edx_django_service_repos: '{{ ANALYTICS_API_REPOS }}'
     edx_django_service_name: '{{ analytics_api_service_name }}'
     edx_django_service_user: '{{ analytics_api_user }}'

--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -7,6 +7,7 @@ edx_django_service_use_python3: true
 edx_django_service_use_python38: false
 edx_django_service_use_python311: false
 edx_django_service_use_python312: false
+edx_django_service_use_vendored_py311: false
 
 # This should be overwritten at the time Ansible is run.
 edx_django_service_is_devstack: false
@@ -276,3 +277,39 @@ edx_django_service_enable_experimental_docker_shim: false
 edx_django_service_docker_run_command_make_migrate: ""
 edx_django_service_docker_run_command_make_static: ""
 edx_django_service_docker_image_name: 'openedx/{{ edx_django_service_name }}'
+
+# Enable installing Python 3.11 on out-of-support Ubuntu. These packages are built
+# using the deadsnakes py3.11 repo and runbook.
+# Base URL for deb packages.
+#
+# For repeatability, we hardcode a commit. (Normally this would be done using a
+# material, but this is intended as a quick hack.)
+vendored_py311_url_base: "https://raw.githubusercontent.com/edx/vendored/c4b7da52935dec033304b723de42ff4505f7d34f/deadsnakes-py3.11-focal"
+# Build string that's present in the deb file names. (Just used to make the
+# names below easier to read.)
+vendored_py311_build: "3.11.13-15-g8adac492d4-1+focal1"
+# These must be kept topologically sorted, dependant packages last, as they
+# will be installed one at a time.
+#
+# The only packages we actually want are python3.11-dev and python3.11-distutils
+# but we need to include all of their dependencies first.
+vendored_py311_pkgs:
+- "libpython3.11-minimal_{{ vendored_py311_build }}_amd64.deb"
+- "python3.11-lib2to3_{{ vendored_py311_build }}_all.deb"
+- "python3.11-minimal_{{ vendored_py311_build }}_amd64.deb"
+- "python3.11-distutils_{{ vendored_py311_build }}_all.deb"
+- "libpython3.11-stdlib_{{ vendored_py311_build }}_amd64.deb"
+- "python3.11_{{ vendored_py311_build }}_amd64.deb"
+- "libpython3.11_{{ vendored_py311_build }}_amd64.deb"
+- "libpython3.11-dev_{{ vendored_py311_build }}_amd64.deb"
+- "python3.11-dev_{{ vendored_py311_build }}_amd64.deb"
+# Packages that are needed for installing the above, but that can be found in
+# the regular Ubuntu repositories.
+py311_dependencies:
+- libssl1.1
+- libexpat1
+- libexpat1-dev
+- mime-support
+- tzdata
+- libreadline8
+- libsqlite3-0

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -76,6 +76,43 @@
     - install
     - install:system-requirements
 
+- name: "Directory for vendored Python 3.11 packages"
+  file:
+    path: "/tmp/vendored_python_{{ vendored_py311_build }}"
+    state: directory
+  when: edx_django_service_use_vendored_py311 and not edx_django_service_enable_experimental_docker_shim
+  tags:
+    - install
+    - install:system-requirements
+
+- name: "Download vendored Python 3.11 packages"
+  get_url:
+    url: "{{ vendored_py311_url_base }}/{{ item|urlencode }}"
+    dest: "/tmp/vendored_python_{{ vendored_py311_build }}/{{ item }}"
+    timeout: 60
+  with_items: "{{ vendored_py311_pkgs }}"
+  when: edx_django_service_use_vendored_py311 and not edx_django_service_enable_experimental_docker_shim
+  tags:
+    - install
+    - install:system-requirements
+
+- name: "Install dependencies for vendored Python 3.11"
+  apt:
+    pkg: "{{ py311_dependencies }}"
+    update_cache: yes
+  when: edx_django_service_use_vendored_py311 and not edx_django_service_enable_experimental_docker_shim
+  tags:
+    - install
+    - install:system-requirements
+
+- name: "Install vendored Python 3.11 packages"
+  command: dpkg -i "/tmp/vendored_python_{{ vendored_py311_build }}/{{ item }}"
+  with_items: "{{ vendored_py311_pkgs }}"
+  when: edx_django_service_use_vendored_py311 and not edx_django_service_enable_experimental_docker_shim
+  tags:
+    - install
+    - install:system-requirements
+
 - name: install python3.12
   apt:
     pkg:
@@ -128,6 +165,16 @@
     creates: "{{ edx_django_service_venv_dir }}/bin/pip"
   become_user: "{{ edx_django_service_user }}"
   when: edx_django_service_use_python311 and not edx_django_service_enable_experimental_docker_shim
+  tags:
+    - install
+    - install:system-requirements
+
+- name: build virtualenv with vendored python3.11
+  command: "virtualenv --python=python3.11 {{ edx_django_service_venv_dir }}"
+  args:
+    creates: "{{ edx_django_service_venv_dir }}/bin/pip"
+  become_user: "{{ edx_django_service_user }}"
+  when: edx_django_service_use_vendored_py311 and not edx_django_service_enable_experimental_docker_shim
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
**Description:** Changes in this PR have been copied from https://github.com/edx/configuration/pull/269, https://github.com/edx/configuration/pull/270 and https://github.com/edx/configuration/pull/272

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
