### PR TITLE
chore: Add distutils for ubuntu 22.04

### DIFF
--- a/playbooks/roles/hermes/tasks/main.yml
+++ b/playbooks/roles/hermes/tasks/main.yml
@@ -32,6 +32,7 @@
   with_items:
     - python3.8
     - python3-pip
+    - python3-distutils
   when: ansible_distribution_release == 'bionic'
   tags:
     - install


### PR DESCRIPTION
Finishes [DOS-6282](https://2u-internal.atlassian.net/browse/DOS-6282)
---
Changes:
- Add distutils as it's not included in 22.04 anymore


Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
