### PR TITLE
fix: upgraded the pinned pip version to 24.0 to sync with latest packages

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -156,7 +156,7 @@ old_python_debian_pkgs:
   - "python2.7=2.7.10-0+{{ ansible_distribution_release }}1"
 
 
-COMMON_PIP_VERSION: '24.2'
+COMMON_PIP_VERSION: '24.0'
 
 common_pip_pkgs:
   - pip=={{ COMMON_PIP_VERSION }}

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -156,7 +156,7 @@ old_python_debian_pkgs:
   - "python2.7=2.7.10-0+{{ ansible_distribution_release }}1"
 
 
-COMMON_PIP_VERSION: '21.2.1'
+COMMON_PIP_VERSION: '24.2'
 
 common_pip_pkgs:
   - pip=={{ COMMON_PIP_VERSION }}


### PR DESCRIPTION
### Description:
Sandbox builds were failing with the following error:
```
AttributeError: 'InstallRequirement' object has no attribute 'use_pep517'
make: *** [Makefile:35: production-requirements] Error 1

```
This occurred because the upgraded `pip-tools` version was incompatible with the pinned `pip==21.2.1`, leading to missing attribute references introduced in newer `pip` versions.

### Solution:
Updated the pinned pip version to `24.0`, which is compatible with the current `pip-tools` release. This aligns with the recommendation to use a version `<24.1`, ensuring compatibility and successful sandbox builds.