### PR TITLE
fix: install python3.8 and python3.8-distutils for hermes on ubuntu jammy(22.04)

### DIFF
--- a/playbooks/roles/hermes/tasks/main.yml
+++ b/playbooks/roles/hermes/tasks/main.yml
@@ -20,7 +20,7 @@
 #
 #
 
-# Install python3.8 on Bionic.Focal comes with python3.8 installed.
+# Install python3.8 on Bionic.Focal comes with python3.8 installed. Jammy does not come with python3.8 installed.
 - name: install python3.8
   apt:
     name: "{{ item }}"
@@ -32,7 +32,17 @@
   with_items:
     - python3.8
     - python3-pip
-  when: ansible_distribution_release == 'bionic'
+  when: ansible_distribution_release == 'bionic' or ansible_distribution_release == 'jammy'
+  tags:
+    - install
+    - install:system-requirements
+
+# Ensure distutils is available for Python 3.8
+- name: Install python3.8-distutils
+  apt:
+    name: python3.8-distutils
+    state: present
+  when: ansible_distribution_release == 'jammy'
   tags:
     - install
     - install:system-requirements
@@ -159,7 +169,7 @@
     dest: "/etc/systemd/system/{{ hermes_service_name }}.service"
     owner: root
     group: root
-  when: ansible_distribution_release == 'xenial' or ansible_distribution_release == 'bionic' or ansible_distribution_release == 'focal'
+  when: ansible_distribution_release in ['xenial', 'bionic', 'focal', 'jammy']
   tags:
     - install
     - install:base
@@ -178,7 +188,7 @@
   service:
     name: "{{ hermes_service_name }}.service"
     enabled: yes
-  when: (ansible_distribution_release == 'xenial' or ansible_distribution_release == 'bionic' or ansible_distribution_release == 'focal') and docker_container.stdout != 'yes'
+  when: ansible_distribution_release in ['xenial', 'bionic', 'focal', 'jammy'] and docker_container.stdout != 'yes'
   tags:
     - install
     - install:base


### PR DESCRIPTION

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
