### PR TITLE
feat: switch to using forked translations

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -207,6 +207,7 @@
 - name: "Pull translations using Atlas"
   shell: |
     source "{{ edxapp_venv_dir }}/bin/activate"
+    export ATLAS_OPTIONS="--repository=edx/openedx-translations --revision=main"
     make pull_translations
   args:
     executable: /usr/bin/bash


### PR DESCRIPTION
we should use our fork of openedx translations for edxapp prod (ec2). not bothering to parameterize this because ec2 is not long for this world.

FIXES: AU-2734

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
