### PR TITLE
fix: Fix pip 25.x compatibility issue in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/edx/ansible.git@stable-1.9.3-rc1-edx#egg=ansible==1.9.3-edx
+ansible @ git+https://github.com/edx/ansible.git@stable-1.9.3-rc1-edx
 PyYAML==3.11
 Jinja2==2.7.3
 MarkupSafe==0.23


### PR DESCRIPTION
### Description:
Jenkins sandbox builds are failing with pip 25.x due to deprecated egg fragment syntax.

### Solution:

**Before:** git+https://github.com/edx/ansible.git@stable-1.9.3-rc1-edx#egg=ansible==1.9.3-edx
**After:** ansible @ git+https://github.com/edx/ansible.git@stable-1.9.3-rc1-edx