### PR TITLE
fix: Set safe.directory when cleaning edxapp git dir

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -66,7 +66,10 @@
 # sometimes cause it? Unclear, but deleting as root should take care of it in
 # any case.)
 - name: git clean after checking out edx-platform
-  shell: cd {{ edxapp_code_dir }} && git clean -xdf
+  # Because the ownership on the dir is different from the user performing the
+  # action, we need to let git know that this dir doesn't have malicious
+  # configs.
+  shell: cd {{ edxapp_code_dir }} && git clean -c safe.directory='{{ edxapp_code_dir }}' -xdf
   tags:
     - install
     - install:code


### PR DESCRIPTION
Git was complaining about the now-mismatched ownership.

This might also be fixed in a newer version of git, but I'm not going to look into that as we're hoping to get rid of all this soon.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
