### PR TITLE
fix: Give git -c arg in correct place

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -69,7 +69,7 @@
   # Because the ownership on the dir is different from the user performing the
   # action, we need to let git know that this dir doesn't have malicious
   # configs.
-  shell: cd {{ edxapp_code_dir }} && git clean -c safe.directory='{{ edxapp_code_dir }}' -xdf
+  shell: cd {{ edxapp_code_dir }} && git -c safe.directory='{{ edxapp_code_dir }}' clean -xdf
   tags:
     - install
     - install:code


### PR DESCRIPTION
It was being ignored because this is supposed to be a top-level option, not a subcommand option.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
