### PR TITLE
revert: Changes to git cleanup in edxapp

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -59,17 +59,9 @@
     - install
     - install:code
 
-# This sometimes sees stale theme-related files that {{edxapp_user}} can't
-# delete, so we're running as root rather than becoming that user. (It's not
-# clear under what conditions this happens -- we thought it was just re-runs but
-# it seems like consecutive builds with the same edx-platform version might
-# sometimes cause it? Unclear, but deleting as root should take care of it in
-# any case.)
 - name: git clean after checking out edx-platform
-  # Because the ownership on the dir is different from the user performing the
-  # action, we need to let git know that this dir doesn't have malicious
-  # configs.
-  shell: cd {{ edxapp_code_dir }} && git -c safe.directory='{{ edxapp_code_dir }}' clean -xdf
+  shell: cd {{ edxapp_code_dir }} && git clean -xdf
+  become_user: "{{ edxapp_user }}"
   tags:
     - install
     - install:code


### PR DESCRIPTION
This reverts commits 270a106669/PR #318, ba8d06deb/PR #319, and 133403dc1/PR #320 which attempted to change to running git-clean as root.

For some reason, git is still saying the directory is unsafe and recommends setting `safe.directory` even though we already are. Just giving up for now. We may need some other approach, such as running `chown -R` on the repo before cleaning or ensuring these files are created with the right ownership in the first place.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
