### PR TITLE
fix: added forum requirement for edge

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -572,6 +572,9 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # XBlocks associated with the LabXchange project
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@a0a8a8dad13199014d4bb29cee416289880bde0b#egg=labxchange-xblocks
       extra_args: -e
+    # forum - currently pointing to ulmo but needs an upgrade when in verawood
+    - name: git+https://github.com/edx/forum.git@release-ulmo#egg=openedx-forum
+      extra_args: -e
     # Caliper and xAPI event routing plugin
     - name: edx-event-routing-backends==5.5.6
     # Other xblocks


### PR DESCRIPTION
### Description

Updated the edxapp Ansible role defaults to ensure Edge/sandbox deployments install the forum package as part of the private Python requirements.

Changes:

Add openedx-forum as a private requirement sourced from the edx/forum repository.
Normalize the edx-arch-experiments requirement line 