### PR TITLE
chore: Matching bump of edx-arch-experiments to 7.1.0

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -587,7 +587,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: ddtrace<4.0.0
 
     # Plugins
-    - name: edx-arch-experiments==6.1.0
+    - name: edx-arch-experiments==7.1.0
 
 # This is an addendum to EDXAPP_PRIVATE_REQUIREMENTS for us in installing
 # requirements only in the stage environment. (It should only be set in stage.)


### PR DESCRIPTION
This is the EC2-side change to match https://github.com/edx/edx-internal/pull/14533 -- we're testing migrations in edxapp edge as part of BOMS-452.

---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
