### PR TITLE
fix: Ignore supervisor "already started" when ensuring edxapp workers…

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -503,6 +503,10 @@
     supervisorctl_path: "{{ supervisor_ctl }}"
     config: "{{ supervisor_cfg }}"
     state: started
+  register: edxapp_workers_start
+  failed_when: >
+    edxapp_workers_start.failed and
+    'already started' not in (edxapp_workers_start.msg | default(''))
   when: celery_worker is defined and not disable_edx_services
   become_user: "{{ supervisor_service_user }}"
   tags:

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -505,8 +505,8 @@
     state: started
   register: edxapp_workers_start
   failed_when: >
-    edxapp_workers_start.failed and
-    'already started' not in (edxapp_workers_start.msg | default(''))
+    edxapp_workers_start is failed and
+    'already started' not in edxapp_workers_start.msg
   when: celery_worker is defined and not disable_edx_services
   become_user: "{{ supervisor_service_user }}"
   tags:


### PR DESCRIPTION
## Summary
- Treat supervisor `ERROR (already started)` as success when ensuring `edxapp_worker` processes are started.
- Keep the existing deploy flow: config update → ensure running → restart to load new code.
- Apply the same fix in all edxapp `deploy.yml` role copies.

**Jira** - [GSRE-4236](https://2u-internal.atlassian.net/browse/GSRE-4236)

## Purpose
CreateSandbox fails only when `enable_datadog=true` because Datadog changes worker startup scripts (`ddtrace-run`), so `supervisorctl update` starts the workers, and the later `ensure edxapp_workers has started` task fails with:
`edxapp_worker:cms_default_1: ERROR (already started)`
This change makes that condition non-fatal so sandbox provisioning can continue, while the final `restart edxapp_workers` task still reloads the newly deployed code.

## Changes
- `playbooks/roles/edxapp/tasks/deploy.yml`