### PR TITLE
fix: disable unattended upgrades in Analytics API service

### DIFF
--- a/playbooks/analyticsapi.yml
+++ b/playbooks/analyticsapi.yml
@@ -6,6 +6,16 @@
     ENABLE_DATADOG: False
     ENABLE_NEWRELIC: False
     CLUSTER_NAME: 'analytics-api'
+    # 2026-07-20: [TEMP] Disable unattended upgrades in all environments as a stop-gap to
+    # fix an issue with the security role forcing an interactive prompt while invoking
+    # `unattended-upgrades`.  Unattended upgrades are already disabled in prod-edge which
+    # is how I know this solution works, so this just does the same in stage-edx and
+    # prod-edx as well.
+    #
+    # Analytics API is the **LAST SERVICE USING ANSIBLE** and it's running an
+    # **UNSUPPORTED UBUNTU 20.04**, so any near-term investment should be focused on
+    # migrating this to k8s, not fixing unattended upgrades.
+    SECURITY_UNATTENDED_UPGRADES: False
   roles:
     - role: aws
       when: COMMON_ENABLE_AWS_ROLE


### PR DESCRIPTION
Meant as a stop-gap to temporarily fix the build stage of the Analytics API GoCD pipeline: https://gocd.tools.edx.org/go/tab/build/detail/edx-analytics-api-stage/128/run_play/1/stage_edx

I think this is the relevant error line:
```
Package ubuntu-pro-client has conffile prompt and needs to be upgraded manually
```

As stated in the code comment, future efforts should be focused on modernization (k8s), not fixing this abandoned ansible infrastructure.
