### PR TITLE
fix: map mongo_version to correct mongo playbook in containerized san…

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -521,6 +521,7 @@ EOF_AUTH
 fi
 
 if [[ $mongo_version == "5.0" ]]; then
+    mongo_playbook="mongo_5_0"
     cat << MONGO_VERSION >> $extra_vars_file
 MONGO_5_0_ENABLED: True
 MONGO_6_0_ENABLED: False
@@ -528,6 +529,7 @@ MONGO_7_0_ENABLED: False
 MONGO_VERSION
 fi
 if [[ $mongo_version == "6.0" ]]; then
+    mongo_playbook="mongo_6_0"
     cat << MONGO_VERSION >> $extra_vars_file
 MONGO_5_0_ENABLED: False
 MONGO_6_0_ENABLED: True
@@ -535,6 +537,7 @@ MONGO_7_0_ENABLED: False
 MONGO_VERSION
 fi
 if [[ $mongo_version == "7.0" ]]; then
+    mongo_playbook="mongo_7_0"
     cat << MONGO_VERSION >> $extra_vars_file
 MONGO_5_0_ENABLED: False
 MONGO_6_0_ENABLED: False
@@ -733,7 +736,7 @@ edxapp_containerized: true
 CAN_GENERATE_NEW_JWT_SIGNATURE: false
 EOF
       ansible -i "${deploy_host}," $deploy_host -m include_role -a "name=memcache" -u ubuntu -b
-      for playbook in redis $mongo_version; do
+      for playbook in redis $mongo_playbook; do
           run_ansible $playbook.yml -i "${deploy_host}," $extra_var_arg --user ubuntu
       done
       run_ansible edx_continuous_integration.yml -i "${deploy_host}," $extra_var_arg --user ubuntu --tags "edxlocal"


### PR DESCRIPTION
## Summary
Fixes containerized sandbox builds failing with `ERROR! the playbook: 5.0.yml could not be found` when `edxapp_container_enabled=true` and `mongo_version=5.0`.

**Jira** - [GSRE-4246](https://2u-internal.atlassian.net/browse/GSRE-4246)

## Purpose
The CreateSandbox Jenkins job sets `mongo_version` to version strings like `5.0`, `6.0`, and `7.0`. The containerized path in `ansible-provision.sh` was using that value directly as the playbook name (`5.0.yml`), while the actual playbooks are `mongo_5_0.yml`, `mongo_6_0.yml`, and `mongo_7_0.yml`. This change maps `mongo_version` to the correct playbook basename in the same block that sets `MONGO_*_ENABLED` flags.

## Changes
- Set `mongo_playbook` to `mongo_5_0`, `mongo_6_0`, or `mongo_7_0` based on the selected `mongo_version` in `ansible-provision.sh`.
- Update the containerized provisioning loop to use `$mongo_playbook` instead of `$mongo_version` when invoking ansible playbooks.