### PR TITLE
fix: pass AWS region when fetching git identity for containerized sandbox builds

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -783,7 +783,7 @@ EOF
 
       set +x
 
-      app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
+      app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id "${configuration_secure_secret}" --query SecretString --output text | jq -r '._local_git_identity')
 
       # specify variable names
       app_hostname="courses"
@@ -961,7 +961,7 @@ fi
 if [[ $edx_exams == 'true' ]]; then
     set +x
     
-    app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
+    app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id "${configuration_secure_secret}" --query SecretString --output text | jq -r '._local_git_identity')
 
     app_hostname="edx-exams"
     app_service_name="edx_exams"
@@ -985,7 +985,7 @@ fi
 if [[ $subscriptions == 'true' ]]; then
     set +x
     
-    app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
+    app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id "${configuration_secure_secret}" --query SecretString --output text | jq -r '._local_git_identity')
     
     app_hostname="subscriptions"
     app_service_name="subscriptions"

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -783,7 +783,7 @@ EOF
 
       set +x
 
-      app_git_ssh_key=$(aws secretsmanager get-secret-value --secret-id  $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
+      app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
 
       # specify variable names
       app_hostname="courses"
@@ -961,7 +961,7 @@ fi
 if [[ $edx_exams == 'true' ]]; then
     set +x
     
-    app_git_ssh_key=$(aws secretsmanager get-secret-value --secret-id  $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
+    app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
 
     app_hostname="edx-exams"
     app_service_name="edx_exams"
@@ -985,7 +985,7 @@ fi
 if [[ $subscriptions == 'true' ]]; then
     set +x
     
-    app_git_ssh_key=$(aws secretsmanager get-secret-value --secret-id  $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
+    app_git_ssh_key=$(aws secretsmanager get-secret-value --region "${region}" --secret-id $configuration_secure_secret --query SecretString --output text | jq -r '._local_git_identity')
     
     app_hostname="subscriptions"
     app_service_name="subscriptions"


### PR DESCRIPTION
## Summary
Fixes containerized sandbox builds failing during edx-themes clone with "Load key invalid format" and "Permission denied (publickey)" errors.

**Jira** - [GSRE-4246](https://2u-internal.atlassian.net/browse/GSRE-4246)

## Purpose
In the containerized path, ansible-provision.sh fetches _local_git_identity from AWS Secrets Manager using the AWS CLI before LMS container provisioning. That call did not include a region, while the non-containerized path uses Ansible aws_secret lookups with region=us-east-1.
This caused the AWS CLI to fail with "You must specify a region", so the git SSH key was never fetched correctly and an empty/invalid key was written to the sandbox host.

## Changes
- Add --region "${region}" to all aws secretsmanager get-secret-value calls in ansible-provision.sh that fetch _local_git_identity.
- Applies to LMS container provisioning, edx_exams, and subscriptions container flows.
- Uses the existing region variable (defaults to us-east-1), matching non-containerized sandbox secret retrieval behavior.