### PR TITLE
fix: authenticate private GitHub repos in containerized sandbox

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -785,9 +785,7 @@ EOF
 
       configuration_secure_json=$(aws secretsmanager get-secret-value --region "${region}" --secret-id "${configuration_secure_secret}" --query SecretString --output text)
       app_git_ssh_key=$(echo "$configuration_secure_json" | jq -r '._local_git_identity // empty')
-      # Required by internal edx-platform-private Dockerfile (BuildKit GIT_AUTH_TOKEN) to fetch
-      # private repos such as edx-internal and edx-themes over HTTPS.
-      app_github_token=$(echo "$configuration_secure_json" | jq -r '.GITHUB_TOKEN // .github_access_token // .github_token // empty')
+      app_git_pat_token=$(echo "$configuration_secure_json" | jq -r '.LOCAL_GIT_PAT_TOKEN // empty')
 
       # specify variable names
       app_hostname="courses"

--- a/util/jenkins/app-container-provisioner.sh
+++ b/util/jenkins/app-container-provisioner.sh
@@ -68,7 +68,7 @@ if ! $(docker image inspect ${app_image_name} >/dev/null 2>&1 && echo true || ec
         curl -fsSL "\$PUBLIC_DOCKERFILE_URL" -o /tmp/edx-platform.Dockerfile
 
         set +x
-        export GITHUB_TOKEN='${app_github_token}'
+        export GITHUB_TOKEN='${app_git_pat_token}'
         set -x
 
         # Public Dockerfile fetches code from GitHub via EDX_PLATFORM_* build args.


### PR DESCRIPTION
## Summary
Fixes containerized sandbox edxapp (LMS/CMS) Docker image build failures when
cloning private `edx/edx-platform` from GitHub.

**Jira** - [GSRE-4332](https://2u-internal.atlassian.net/browse/GSRE-4332)

## Purpose
Containerized sandboxes (`edxapp_container_enabled=true`) no longer build from an
in-repo Dockerfile. They use:
- `public-dockerfiles/dockerfiles/edx-platform.Dockerfile` for the base image
- `internal-dockerfiles/edx-platform-private` for the private overlay

The public Dockerfile fetches edx-platform inside the image with:

`ADD https://github.com/${EDX_PLATFORM_REPO}.git#${EDX_PLATFORM_VERSION}`

For sandbox, `EDX_PLATFORM_REPO=edx/edx-platform` (private). BuildKit requires
a GitHub PAT passed as `--secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN`, matching
the production GoCD edxapp build pattern.

## Changes

- **`ansible-provision.sh`**
  - Read `LOCAL_GIT_PAT_TOKEN` from `configuration_secure_secret` (AWS Secrets Manager)
  - Pass it to LMS/CMS container provisioning as `app_git_pat_token`

- **`app-container-provisioner.sh`**
  - Export `GITHUB_TOKEN` from `app_git_pat_token` during edx-platform image build
  - Pass `--secret id=GIT_AUTH_TOKEN,env=GITHUB_TOKEN` to:
    - public `edx-platform.Dockerfile` base build
    - private `edx-platform-private` LMS/CMS overlay build