### PR TITLE
fix: add Jammy package mapping for Insights

### DIFF
--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -272,3 +272,4 @@ insights_release_specific_debian_pkgs:
     - openjdk-8-jdk
   focal:
     - openjdk-8-jdk
+  jammy: []


### PR DESCRIPTION
Adds the missing Ubuntu Jammy package mapping for the Insights Ansible role.

The Insights role indexes `insights_release_specific_debian_pkgs` using `ansible_distribution_release`. After moving the Insights deployment VM to Ubuntu 22.04, Ansible will resolve the release as `jammy`, so this key needs to exist.

## Changes

- Added `jammy: []` to `insights_release_specific_debian_pkgs`.