### PR TITLE
fix: skip Insights deploy-time security upgrade

### DIFF
--- a/playbooks/insights.yml
+++ b/playbooks/insights.yml
@@ -6,6 +6,7 @@
     ENABLE_DATADOG: False
     ENABLE_NEWRELIC: True
     CLUSTER_NAME: 'insights'
+    SECURITY_UPGRADE_ON_ANSIBLE: False
   roles:
     - role: aws
       when: COMMON_ENABLE_AWS_ROLE


### PR DESCRIPTION
This PR disables the deploy-time security upgrade step for the Insights playbook by setting `SECURITY_UPGRADE_ON_ANSIBLE` to `False`.

The Insights deployment pipeline has not been actively used/validated for a long time. While bringing it back, we found a few environment compatibility issues. The application/deployment is now using Python 3.12, so the Insights VM had to be moved from Ubuntu 20.04 to Ubuntu 22.04 because Ubuntu 20.04 does not provide the required Python 3.12 packages.

After moving to Ubuntu 22.04, the pipeline moved further but started failing during the Ansible security update step. The failure is caused by `unattended-upgrade` trying to upgrade `ubuntu-pro-client`, which needs a manual config-file prompt. Since GoCD/Ansible runs non-interactively, it cannot answer that prompt and the deployment fails.

This change does not remove security configuration from the server. It only skips running the immediate `unattended-upgrade` command during the Insights deployment, so the deployment can continue without getting blocked by a manual package prompt.
