### PR TITLE
fix: guard Insights SplunkForwarder role

### DIFF
--- a/playbooks/insights.yml
+++ b/playbooks/insights.yml
@@ -17,6 +17,7 @@
     - role: datadog
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
+      when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: datadog-uninstall
       when: not COMMON_ENABLE_DATADOG
     - role: hermes


### PR DESCRIPTION
## Summary
Adds the existing `COMMON_ENABLE_SPLUNKFORWARDER` guard to the Insights playbook before running the SplunkForwarder role.

The team confirmed SplunkForwarder is no longer needed for the Insights deployment, so this keeps the role optional and aligns Insights with the pattern already used by other playbooks.
