### PR TITLE
fix: stop sandbox edx-platform images from creating k8s tracking log dirs

### DIFF
--- a/util/jenkins/app-container-provisioner.sh
+++ b/util/jenkins/app-container-provisioner.sh
@@ -66,10 +66,10 @@ if ! $(docker image inspect ${app_image_name} >/dev/null 2>&1 && echo true || ec
         PUBLIC_DOCKERFILE_URL="https://raw.githubusercontent.com/edx/public-dockerfiles/main/dockerfiles/edx-platform.Dockerfile"
         echo "Downloading public edx-platform Dockerfile from GitHub..."
         curl -fsSL "\$PUBLIC_DOCKERFILE_URL" -o /tmp/edx-platform.Dockerfile
-        # Undo GSRE-3740 (k8s EFS tracking path) on this copy only; keep later syslog_format.
-        # https://github.com/edx/public-dockerfiles/commit/5a51c0034be4f4c3bdbf0fb45945559b2b2555b5
+        # Strip k8s tracking-log path from this copy only; keep later syslog_format.
         sed -i '/RUN mkdir -p \/edx\/var\/log\/tracking && chown -R app:app \/edx\/var\/log/d' /tmp/edx-platform.Dockerfile
-        sed -i '/_tracking_log_dir = os.path.join(/,/^}$/d' /tmp/edx-platform.Dockerfile
+        sed -i '/_tracking_log_dir = os.path.join(/,/^[[:space:]]*}[[:space:]]*$/d' /tmp/edx-platform.Dockerfile
+        grep -q "_tracking_log_dir = os.path.join" /tmp/edx-platform.Dockerfile && { echo "Failed to strip k8s tracking log dir logic from edx-platform.Dockerfile"; exit 1; }
 
         set +x
         export GITHUB_TOKEN='${app_git_pat_token}'

--- a/util/jenkins/app-container-provisioner.sh
+++ b/util/jenkins/app-container-provisioner.sh
@@ -66,6 +66,10 @@ if ! $(docker image inspect ${app_image_name} >/dev/null 2>&1 && echo true || ec
         PUBLIC_DOCKERFILE_URL="https://raw.githubusercontent.com/edx/public-dockerfiles/main/dockerfiles/edx-platform.Dockerfile"
         echo "Downloading public edx-platform Dockerfile from GitHub..."
         curl -fsSL "\$PUBLIC_DOCKERFILE_URL" -o /tmp/edx-platform.Dockerfile
+        # Undo GSRE-3740 (k8s EFS tracking path) on this copy only; keep later syslog_format.
+        # https://github.com/edx/public-dockerfiles/commit/5a51c0034be4f4c3bdbf0fb45945559b2b2555b5
+        sed -i '/RUN mkdir -p \/edx\/var\/log\/tracking && chown -R app:app \/edx\/var\/log/d' /tmp/edx-platform.Dockerfile
+        sed -i '/_tracking_log_dir = os.path.join(/,/^}$/d' /tmp/edx-platform.Dockerfile
 
         set +x
         export GITHUB_TOKEN='${app_git_pat_token}'

--- a/util/jenkins/worker-container-provisioner.sh
+++ b/util/jenkins/worker-container-provisioner.sh
@@ -73,6 +73,8 @@ if docker image inspect edx-platform:latest >/dev/null 2>&1; then
 elif ! docker image inspect ${LC_WORKER_IMAGE_NAME}:latest >/dev/null 2>&1; then
   PUBLIC_DOCKERFILE_URL="https://raw.githubusercontent.com/edx/public-dockerfiles/main/dockerfiles/edx-platform.Dockerfile"
   curl -fsSL "${PUBLIC_DOCKERFILE_URL}" -o /tmp/edx-platform.Dockerfile
+  sed -i '/RUN mkdir -p \/edx\/var\/log\/tracking && chown -R app:app \/edx\/var\/log/d' /tmp/edx-platform.Dockerfile
+  sed -i '/_tracking_log_dir = os.path.join(/,/^}$/d' /tmp/edx-platform.Dockerfile
   time DOCKER_BUILDKIT=1 docker build \
     -f /tmp/edx-platform.Dockerfile \
     --target base \

--- a/util/jenkins/worker-container-provisioner.sh
+++ b/util/jenkins/worker-container-provisioner.sh
@@ -73,8 +73,13 @@ if docker image inspect edx-platform:latest >/dev/null 2>&1; then
 elif ! docker image inspect ${LC_WORKER_IMAGE_NAME}:latest >/dev/null 2>&1; then
   PUBLIC_DOCKERFILE_URL="https://raw.githubusercontent.com/edx/public-dockerfiles/main/dockerfiles/edx-platform.Dockerfile"
   curl -fsSL "${PUBLIC_DOCKERFILE_URL}" -o /tmp/edx-platform.Dockerfile
+  # Strip k8s tracking-log path from this copy only; keep later syslog_format.
   sed -i '/RUN mkdir -p \/edx\/var\/log\/tracking && chown -R app:app \/edx\/var\/log/d' /tmp/edx-platform.Dockerfile
-  sed -i '/_tracking_log_dir = os.path.join(/,/^}$/d' /tmp/edx-platform.Dockerfile
+  sed -i '/_tracking_log_dir = os.path.join(/,/^[[:space:]]*}[[:space:]]*$/d' /tmp/edx-platform.Dockerfile
+  if grep -q '_tracking_log_dir' /tmp/edx-platform.Dockerfile; then
+    echo "ERROR: k8s tracking-log override still present in edx-platform.Dockerfile after strip" >&2
+    exit 1
+  fi
   time DOCKER_BUILDKIT=1 docker build \
     -f /tmp/edx-platform.Dockerfile \
     --target base \


### PR DESCRIPTION
## Summary
Fixes containerized CreateSandbox failing at LMS JWT generation with: `PermissionError: [Errno 13] Permission denied: '/edx/var/log/tracking/unknown-node'`

**Jira** - [GSRE-4414](https://2u-internal.atlassian.net/browse/GSRE-4414)

## Purpose
The public edx-platform Dockerfile writes `docker-production.py` that always creates `/edx/var/log/tracking/<NODE_NAME>/<POD_NAME>/` for k8s. Sandbox has neither those env vars nor an `app` user writable path (`www-data`), so settings import dies before JWT, migrations, or compose. That tracking layout must stay in public-dockerfiles for stage/edge/prod. Sandbox strips it only from the **downloaded** copy used on the EC2 host.

## Changes
- `app-container-provisioner.sh`: after curl, `sed` out the tracking `mkdir` and `_tracking_log_dir` / tracking file handler; keep later `syslog_format`
- `worker-container-provisioner.sh`: same `sed` on the public-Dockerfile fallback build